### PR TITLE
Add JaCoCo coverage reporting and SonarQube integration. Closes #4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+gradlew text eol=lf
+*.sh text eol=lf
+gradlew.bat text eol=crlf

--- a/auth-server/build.gradle.kts
+++ b/auth-server/build.gradle.kts
@@ -38,7 +38,6 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
-	finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.jacocoTestReport {
@@ -47,12 +46,6 @@ tasks.jacocoTestReport {
 		xml.required.set(true)
 		csv.required.set(false)
 		html.required.set(true)
-	}
-}
-
-sonar {
-	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
 }
 

--- a/auth-server/build.gradle.kts
+++ b/auth-server/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	jacoco
 	id("org.springframework.boot") version "3.5.11"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.sonarqube") version "7.2.3.7755"
@@ -37,4 +38,20 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	reports {
+		xml.required.set(true)
+		csv.required.set(false)
+		html.required.set(true)
+	}
+}
+
+sonar {
+	properties {
+		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+	}
 }

--- a/auth-server/build.gradle.kts
+++ b/auth-server/build.gradle.kts
@@ -52,6 +52,10 @@ tasks.jacocoTestReport {
 
 sonar {
 	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
+}
+
+tasks.named("sonar") {
+	dependsOn(tasks.jacocoTestReport)
 }

--- a/config-server/build.gradle.kts
+++ b/config-server/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	jacoco
 	id("org.springframework.boot") version "3.5.11"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.sonarqube") version "7.2.3.7755"
@@ -34,4 +35,20 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	reports {
+		xml.required.set(true)
+		csv.required.set(false)
+		html.required.set(true)
+	}
+}
+
+sonar {
+	properties {
+		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+	}
 }

--- a/config-server/build.gradle.kts
+++ b/config-server/build.gradle.kts
@@ -35,7 +35,6 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
-	finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.jacocoTestReport {
@@ -44,12 +43,6 @@ tasks.jacocoTestReport {
 		xml.required.set(true)
 		csv.required.set(false)
 		html.required.set(true)
-	}
-}
-
-sonar {
-	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
 }
 

--- a/config-server/build.gradle.kts
+++ b/config-server/build.gradle.kts
@@ -49,6 +49,10 @@ tasks.jacocoTestReport {
 
 sonar {
 	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
+}
+
+tasks.named("sonar") {
+	dependsOn(tasks.jacocoTestReport)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,16 @@ services:
         :eureka-server:classes
         :watermark-service:classes
         :watermark-client:classes
+        :auth-server:test
+        :config-server:test
+        :eureka-server:test
+        :watermark-service:test
+        :watermark-client:test
+        :auth-server:jacocoTestReport
+        :config-server:jacocoTestReport
+        :eureka-server:jacocoTestReport
+        :watermark-service:jacocoTestReport
+        :watermark-client:jacocoTestReport
         :auth-server:sonar
         :config-server:sonar
         :eureka-server:sonar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,21 +120,6 @@ services:
       - -lc
       - >
         gradle --no-daemon
-        :auth-server:classes
-        :config-server:classes
-        :eureka-server:classes
-        :watermark-service:classes
-        :watermark-client:classes
-        :auth-server:test
-        :config-server:test
-        :eureka-server:test
-        :watermark-service:test
-        :watermark-client:test
-        :auth-server:jacocoTestReport
-        :config-server:jacocoTestReport
-        :eureka-server:jacocoTestReport
-        :watermark-service:jacocoTestReport
-        :watermark-client:jacocoTestReport
         :auth-server:sonar
         :config-server:sonar
         :eureka-server:sonar

--- a/eureka-server/build.gradle.kts
+++ b/eureka-server/build.gradle.kts
@@ -50,6 +50,10 @@ tasks.jacocoTestReport {
 
 sonar {
 	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
+}
+
+tasks.named("sonar") {
+	dependsOn(tasks.jacocoTestReport)
 }

--- a/eureka-server/build.gradle.kts
+++ b/eureka-server/build.gradle.kts
@@ -36,7 +36,6 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
-	finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.jacocoTestReport {
@@ -45,12 +44,6 @@ tasks.jacocoTestReport {
 		xml.required.set(true)
 		csv.required.set(false)
 		html.required.set(true)
-	}
-}
-
-sonar {
-	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
 }
 

--- a/eureka-server/build.gradle.kts
+++ b/eureka-server/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	jacoco
 	id("org.springframework.boot") version "3.5.11"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.sonarqube") version "7.2.3.7755"
@@ -35,4 +36,20 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	reports {
+		xml.required.set(true)
+		csv.required.set(false)
+		html.required.set(true)
+	}
+}
+
+sonar {
+	properties {
+		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+	}
 }

--- a/watermark-client/build.gradle.kts
+++ b/watermark-client/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	jacoco
 	id("org.springframework.boot") version "3.5.11"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.sonarqube") version "7.2.3.7755"
@@ -39,4 +40,20 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	reports {
+		xml.required.set(true)
+		csv.required.set(false)
+		html.required.set(true)
+	}
+}
+
+sonar {
+	properties {
+		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+	}
 }

--- a/watermark-client/build.gradle.kts
+++ b/watermark-client/build.gradle.kts
@@ -40,7 +40,6 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
-	finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.jacocoTestReport {
@@ -49,12 +48,6 @@ tasks.jacocoTestReport {
 		xml.required.set(true)
 		csv.required.set(false)
 		html.required.set(true)
-	}
-}
-
-sonar {
-	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
 }
 

--- a/watermark-client/build.gradle.kts
+++ b/watermark-client/build.gradle.kts
@@ -54,6 +54,10 @@ tasks.jacocoTestReport {
 
 sonar {
 	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
+}
+
+tasks.named("sonar") {
+	dependsOn(tasks.jacocoTestReport)
 }

--- a/watermark-service/build.gradle.kts
+++ b/watermark-service/build.gradle.kts
@@ -53,6 +53,10 @@ tasks.jacocoTestReport {
 
 sonar {
 	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
+}
+
+tasks.named("sonar") {
+	dependsOn(tasks.jacocoTestReport)
 }

--- a/watermark-service/build.gradle.kts
+++ b/watermark-service/build.gradle.kts
@@ -39,7 +39,6 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
-	finalizedBy(tasks.jacocoTestReport)
 }
 
 tasks.jacocoTestReport {
@@ -48,12 +47,6 @@ tasks.jacocoTestReport {
 		xml.required.set(true)
 		csv.required.set(false)
 		html.required.set(true)
-	}
-}
-
-sonar {
-	properties {
-		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
 }
 

--- a/watermark-service/build.gradle.kts
+++ b/watermark-service/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	java
+	jacoco
 	id("org.springframework.boot") version "3.5.11"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.sonarqube") version "7.2.3.7755"
@@ -38,4 +39,20 @@ dependencyManagement {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+	reports {
+		xml.required.set(true)
+		csv.required.set(false)
+		html.required.set(true)
+	}
+}
+
+sonar {
+	properties {
+		property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("reports/jacoco/test/jacocoTestReport.xml").get().asFile.absolutePath)
+	}
 }


### PR DESCRIPTION
This PR adds JaCoCo-based code coverage reporting to all microservice modules and integrates the generated reports with SonarQube.

- added JaCoCo plugin configuration to all subprojects
- configured jacocoTestReport to generate XML coverage reports
- connected SonarQube to JaCoCo XML reports using sonar.coverage.jacoco.xmlReportPaths
- updated the Docker Sonar scan workflow to run tests and generate JaCoCo reports before Sonar analysis