### PR TITLE
fix: raise ai-service multipart limit to 20MB

### DIFF
--- a/ai-service/src/main/resources/application.yaml
+++ b/ai-service/src/main/resources/application.yaml
@@ -3,3 +3,10 @@ spring:
     name: ai-service
   config:
     import: "optional:configserver:http://localhost:8888"
+  servlet:
+    multipart:
+      # Match watermark-service (20MB) and the nginx client_max_body_size (20m).
+      # The default 1MB rejected larger photos forwarded from watermark-service
+      # with a 500 before they reached the classifier.
+      max-file-size: 20MB
+      max-request-size: 25MB


### PR DESCRIPTION
## Problem
`ai-service` had no multipart config, so it used Spring Boot's default `max-file-size=1MB`. `watermark-service` is set to 20MB, so a photo >1MB passed embed but its Feign re-send to `ai-service /api/classify` was rejected with `MaxUploadSizeExceededException` → `500 {"error":"Internal server error"}`. The watermark embed still succeeded, but the AI category came back `unknown` (block hidden in the GUI).

## Fix
Set `ai-service` multipart limits to match `watermark-service` (20MB) and the nginx `client_max_body_size` (20m). config-server defines no multipart key, so this local value takes effect.

## Verification (rebuilt ai-service locally)
- Direct to ai-service: 1.57MB & 5MB → `200` (previously 500 / connection reset); small → 200
- End-to-end in browser: 5MB image → `Wykryta klasa: bird (kite) 3%`