### PR TITLE
Harden watermark-service-py: AES-GCM crypto, config-server, adaptive capacity (closes #23)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Python local virtualenvs — these are huge (torch/cuda wheels)
+# and never needed in Docker build context
+**/.venv/
+**/venv/
+**/test_env/
+**/__pycache__/
+**/*.pyc
+**/.pytest_cache/
+
+# Gradle build artifacts (each service builds its own jar inside the image)
+**/build/
+**/.gradle/
+
+# IDE / OS
+.idea/
+.vscode/
+.DS_Store
+
+# Git / docs (most services don't need)
+.git/
+*.md
+docs/
+
+# Local
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,18 @@
 .env
 
+docs/superpowers/
+
+# Python
+**/.venv/
+**/venv/
+**/test_env/
+**/__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.coverage
+htmlcov/
+
 # Created by https://www.toptal.com/developers/gitignore/api/linux,windows,java,gradle,intellij,visualstudiocode,netbeans
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,windows,java,gradle,intellij,visualstudiocode,netbeans
 

--- a/ai-service/src/main/java/pl/zzpj/ai_service/ClassificationResult.java
+++ b/ai-service/src/main/java/pl/zzpj/ai_service/ClassificationResult.java
@@ -14,6 +14,7 @@ public record ClassificationResult(
         String label,
         String category,
         double confidence,
+        double categoryConfidence,
         List<TopPrediction> top3
 ) {
     /**

--- a/ai-service/src/main/java/pl/zzpj/ai_service/ClassificationService.java
+++ b/ai-service/src/main/java/pl/zzpj/ai_service/ClassificationService.java
@@ -40,6 +40,7 @@ public class ClassificationService {
     private OrtEnvironment environment;
     private OrtSession session;
     private List<String> labels;
+    private String[] labelCategories;
     private String inputName;
 
     /**
@@ -59,6 +60,7 @@ public class ClassificationService {
         }
 
         labels = Files.readAllLines(synsetFile);
+        labelCategories = labels.stream().map(CategoryMapper::map).toArray(String[]::new);
         log.info("Loaded {} class labels from {}", labels.size(), synsetFile.getFileName());
 
         environment = OrtEnvironment.getEnvironment();
@@ -100,13 +102,23 @@ public class ClassificationService {
 
         String bestLabel = labels.get(topIndices[0]);
         double bestConfidence = round4(probs[topIndices[0]]);
-        String category = CategoryMapper.map(bestLabel);
+        String category = labelCategories[topIndices[0]];
+
+        double categoryConfidence = 0.0;
+        if (!"other".equals(category)) {
+            for (int i = 0; i < probs.length; i++) {
+                if (category.equals(labelCategories[i])) {
+                    categoryConfidence += probs[i];
+                }
+            }
+        }
 
         List<ClassificationResult.TopPrediction> top3 = Arrays.stream(topIndices)
                 .mapToObj(i -> new ClassificationResult.TopPrediction(labels.get(i), round4(probs[i])))
                 .toList();
 
-        return new ClassificationResult(bestLabel, category, bestConfidence, top3);
+        double clampedCategoryConfidence = Math.min(1.0, categoryConfidence);
+        return new ClassificationResult(bestLabel, category, bestConfidence, round4(clampedCategoryConfidence), top3);
     }
 
     private float[] preprocess(InputStream is) throws IOException {

--- a/ai-service/src/main/java/pl/zzpj/ai_service/exception/GlobalExceptionHandler.java
+++ b/ai-service/src/main/java/pl/zzpj/ai_service/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package pl.zzpj.ai_service.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -18,6 +20,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleGenericException(Exception exception) {
+        log.error("Unhandled exception in ai-service", exception);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(Map.of("error", "Internal server error"));
     }

--- a/ai-service/src/test/java/pl/zzpj/ai_service/ClassificationServiceTest.java
+++ b/ai-service/src/test/java/pl/zzpj/ai_service/ClassificationServiceTest.java
@@ -44,6 +44,11 @@ class ClassificationServiceTest {
                 "Samoyed image should map to 'dog' category, got label='" + result.label() + "'");
         assertTrue(result.confidence() > 0.1,
                 "Top-1 confidence should be > 0.1, got " + result.confidence());
+        assertTrue(result.categoryConfidence() >= result.confidence(),
+                "categoryConfidence should be >= top-1 confidence when top-1 is in the category, got "
+                        + result.categoryConfidence() + " vs " + result.confidence());
+        assertTrue(result.categoryConfidence() <= 1.0,
+                "categoryConfidence must not exceed 1.0, got " + result.categoryConfidence());
         assertEquals(3, result.top3().size());
         assertTrue(result.top3().get(0).confidence() >= result.top3().get(1).confidence(),
                 "top3 must be sorted by descending confidence");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,18 +89,27 @@ services:
 
   watermark-service:
     build:
-      context: .
-      dockerfile: watermark-service/Dockerfile
+      context: ./watermark-service-py
+      dockerfile: Dockerfile
     container_name: watermark-service
     environment:
-      SPRING_CONFIG_IMPORT: configserver:http://config-server:8888
+      CONFIG_SERVER_URL: http://config-server:8888
       EUREKA_URL: http://eureka-server:8761/eureka/
+      AUTH_SERVER_URL: http://auth-server:8081
+      AI_SERVICE_URL: http://ai-service:8084
+      WATERMARK_APP_KEY: ${WATERMARK_APP_KEY:-local-dev-watermark-secret}
+      # Acknowledges the dev-default app key fallback above so the service boots.
+      # In production, set WATERMARK_APP_KEY to a real secret and leave this unset.
+      WATERMARK_DEV_MODE: "true"
+      INSTANCE_HOSTNAME: watermark-service
     ports:
       - "8082:8082"
     depends_on:
       config-server:
         condition: service_healthy
       eureka-server:
+        condition: service_started
+      auth-server:
         condition: service_started
       ai-service:
         condition: service_started

--- a/gui/src/routes/+page.svelte
+++ b/gui/src/routes/+page.svelte
@@ -19,9 +19,16 @@
     let embedProcessing = $state(false);
     /** @type {string | null} */
     let resultImageUrl = $state(null);
-    /** @type {{ category: string, label: string | null, confidence: number | null } | null} */
+    /** @type {{ category: string, label: string | null, confidence: number | null, categoryConfidence: number | null } | null} */
     let classification = $state(null);
     let embedError = $state('');
+    /** @type {{ maxTextBytes: number, minImageWidth: number, minImageHeight: number, imageWidth: number, imageHeight: number, imageOk: boolean, lengthBits: number } | null} */
+    let capacity = $state(null);
+    let capacityChecking = $state(false);
+    /** @type {string | null} */
+    let capacityError = $state(null);
+    /** @type {AbortController | null} */
+    let capacityAbort = null;
 
     // --- Detect ---
     let detectFiles = $state();
@@ -94,11 +101,90 @@
         }
     }
 
+    // Bytes-not-chars: backend measures payload in UTF-8 bytes, so multibyte
+    // characters (ą, ł, emoji) eat more capacity than ASCII. Mirror that here.
+    const textEncoder = new TextEncoder();
+    /** @param {string} text */
+    function utf8ByteLength(text) {
+        return textEncoder.encode(text).length;
+    }
+
+    let lastProbedFileSignature = '';
+
+    /** @param {File} file */
+    function fileSignature(file) {
+        return `${file.name}|${file.size}|${file.lastModified}`;
+    }
+
+    async function probeCapacity() {
+        if (!embedFiles || embedFiles.length === 0) return;
+        // Cancel any in-flight probe so an earlier file's response can't overwrite
+        // state for a newer selection.
+        capacityAbort?.abort();
+        const controller = new AbortController();
+        capacityAbort = controller;
+        capacity = null;
+        capacityError = null;
+        capacityChecking = true;
+        try {
+            const formData = new FormData();
+            formData.append('image', embedFiles[0]);
+            const response = await fetch('/api/watermark/capacity', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${token}` },
+                body: formData,
+                signal: controller.signal
+            });
+            if (controller.signal.aborted) return;
+            if (response.ok) {
+                capacity = await response.json();
+            } else {
+                capacityError = await readError(response);
+            }
+        } catch (err) {
+            if (err instanceof DOMException && err.name === 'AbortError') return;
+            capacityError = 'Nie udało się sprawdzić pojemności obrazu.';
+        } finally {
+            if (capacityAbort === controller) {
+                capacityAbort = null;
+                capacityChecking = false;
+            }
+        }
+    }
+
+    $effect(() => {
+        // Refetch capacity only when the user actually picked a new file —
+        // re-binding the same FileList shouldn't trigger another upload.
+        if (embedFiles && embedFiles.length > 0) {
+            const sig = fileSignature(embedFiles[0]);
+            if (sig !== lastProbedFileSignature) {
+                lastProbedFileSignature = sig;
+                probeCapacity();
+            }
+        } else {
+            lastProbedFileSignature = '';
+            capacity = null;
+            capacityError = null;
+        }
+    });
+
     async function embedWatermark() {
         const validation = validateImage(embedFiles);
         if (validation) { embedError = validation; return; }
         if (!watermarkText || watermarkText.trim() === '') {
             embedError = 'Wpisz tekst, który chcesz ukryć w obrazie.';
+            return;
+        }
+        if (capacityChecking) {
+            embedError = 'Poczekaj na sprawdzenie pojemności obrazu.';
+            return;
+        }
+        if (capacity && !capacity.imageOk) {
+            embedError = `Obraz jest za mały (${capacity.imageWidth}×${capacity.imageHeight}). Minimum to ${capacity.minImageWidth}×${capacity.minImageHeight} px.`;
+            return;
+        }
+        if (capacity && utf8ByteLength(watermarkText) > capacity.maxTextBytes) {
+            embedError = `Tekst jest za długi — maksymalnie ${capacity.maxTextBytes} bajtów dla tego obrazu.`;
             return;
         }
 
@@ -227,15 +313,19 @@
         const category = headers.get('X-Image-Category');
         const label = headers.get('X-Image-Label');
         const confidence = headers.get('X-Image-Confidence');
+        const categoryConfidence = headers.get('X-Image-Category-Confidence');
 
         if (!category || category === 'unknown') {
             return null;
         }
 
+        const toPercent = (v) => (v ? Math.round(parseFloat(v) * 100) : null);
+
         return {
             category,
             label: label && label !== 'unknown' ? label : null,
-            confidence: confidence ? Math.round(parseFloat(confidence) * 100) : null
+            confidence: toPercent(confidence),
+            categoryConfidence: toPercent(categoryConfidence)
         };
     }
 </script>
@@ -261,19 +351,44 @@
     {#if activeTab === 'embed'}
         <div class="card">
             <h3>Osadź znak wodny</h3>
-            <p class="subtitle">Wybierz obraz i wpisz tajną wiadomość, która zostanie w nim niewidocznie ukryta.</p>
+            <p class="subtitle">Wybierz obraz PNG i wpisz tajną wiadomość, która zostanie w nim niewidocznie ukryta.</p>
+
+            <p class="hint">Plik wynikowy zostaje PNG-iem — kompresja JPG, screenshot lub edycja usuwa znak wodny.</p>
 
             <div class="form-group">
-                <label for="embed-file">Obraz bazowy (PNG/JPG):</label>
-                <input id="embed-file" type="file" accept="image/png, image/jpeg" bind:files={embedFiles} class="input-file" />
+                <label for="embed-file">Obraz bazowy (PNG):</label>
+                <input id="embed-file" type="file" accept="image/png" bind:files={embedFiles} class="input-file" />
             </div>
 
+            {#if capacityChecking}
+                <div class="capacity-info capacity-info--pending">⏳ Sprawdzanie pojemności obrazu…</div>
+            {:else if capacityError}
+                <div class="capacity-info capacity-info--error">⚠️ {capacityError}</div>
+            {:else if capacity && !capacity.imageOk}
+                <div class="capacity-info capacity-info--error">
+                    ⚠️ Obraz jest za mały: <strong>{capacity.imageWidth}×{capacity.imageHeight} px</strong>.
+                    Minimum to <strong>{capacity.minImageWidth}×{capacity.minImageHeight} px</strong>.
+                </div>
+            {:else if capacity}
+                <div class="capacity-info" role="status" aria-live="polite">
+                    📐 <strong>{capacity.imageWidth}×{capacity.imageHeight} px</strong> — możesz ukryć maksymalnie
+                    <strong>{capacity.maxTextBytes} bajtów</strong> (znaki ASCII = 1 bajt, polskie znaki = 2 bajty).
+                </div>
+            {/if}
+
             <div class="form-group">
-                <label for="watermark-text">Ukryty tekst:</label>
+                <label for="watermark-text">
+                    Ukryty tekst:
+                    {#if capacity && capacity.imageOk}
+                        <span class="char-counter" class:char-counter--over={utf8ByteLength(watermarkText) > capacity.maxTextBytes}>
+                            {utf8ByteLength(watermarkText)} / {capacity.maxTextBytes} B
+                        </span>
+                    {/if}
+                </label>
                 <input id="watermark-text" type="text" bind:value={watermarkText} placeholder="Np. Prawa autorskie - Jan Kowalski" class="input-text" />
             </div>
 
-            <button class="btn btn-primary" onclick={embedWatermark} disabled={embedProcessing}>
+            <button class="btn btn-primary" onclick={embedWatermark} disabled={embedProcessing || capacityChecking || (capacity !== null && !capacity.imageOk)}>
                 {embedProcessing ? '⏳ Przetwarzanie...' : '✨ Generuj obraz'}
             </button>
 
@@ -290,11 +405,13 @@
                     <div class="classification">
                         <span class="classification-label">Wykryta klasa:</span>
                         <span class="classification-category">{classification.category}</span>
-                        {#if classification.label}
-                            <span class="classification-detail">({classification.label})</span>
+                        {#if classification.categoryConfidence !== null && classification.categoryConfidence > 0}
+                            <span class="classification-confidence">{classification.categoryConfidence}%</span>
                         {/if}
-                        {#if classification.confidence !== null}
-                            <span class="classification-confidence">{classification.confidence}%</span>
+                        {#if classification.label}
+                            <span class="classification-detail">
+                                · {classification.label}{classification.confidence !== null ? ` (${classification.confidence}%)` : ''}
+                            </span>
                         {/if}
                     </div>
                 {/if}
@@ -303,14 +420,15 @@
                     <img src={resultImageUrl} alt="Obraz ze znakiem wodnym" />
                 </div>
                 <a href={resultImageUrl} download="watermarked_image.png" class="download-link">
-                    <button class="btn btn-success">⬇️ Pobierz obraz</button>
+                    <button class="btn btn-success">⬇️ Pobierz obraz (PNG)</button>
                 </a>
+                <p class="hint hint--result">Trzymaj jako PNG — rekompresja niszczy znak.</p>
             </div>
         {/if}
     {:else if activeTab === 'detect'}
         <div class="card">
             <h3>Wykryj znak wodny</h3>
-            <p class="subtitle">Sprawdź, czy obraz zawiera znak wodny osadzony przez ten serwis.</p>
+            <p class="subtitle">Sprawdź, czy obraz zawiera znak wodny osadzony przez ten serwis. Działa tylko na nieprzetworzonym PNG-u.</p>
 
             <div class="form-group">
                 <label for="detect-file">Obraz do sprawdzenia (PNG/JPG):</label>
@@ -347,7 +465,7 @@
     {:else if activeTab === 'extract'}
         <div class="card">
             <h3>Wyodrębnij ukryty tekst</h3>
-            <p class="subtitle">Odczytaj treść ukrytą w obrazie. Dostęp ma tylko właściciel znaku wodnego.</p>
+            <p class="subtitle">Odczytaj treść ukrytą w obrazie. Dostęp ma tylko właściciel znaku wodnego. Działa tylko na nieprzetworzonym PNG-u.</p>
 
             <div class="form-group">
                 <label for="extract-file">Obraz ze znakiem (PNG/JPG):</label>
@@ -378,7 +496,7 @@
     {:else if activeTab === 'visualize'}
         <div class="card">
             <h3>Wizualizuj znak wodny</h3>
-            <p class="subtitle">Podświetla bloki 8×8, w których ukryto dane. Najpierw sprawdzamy, czy obraz w ogóle zawiera znak wodny.</p>
+            <p class="subtitle">Mapa cieplna pokazuje, gdzie w obrazie zostały zapisane dane. Działa tylko na nieprzetworzonym PNG-u.</p>
 
             <div class="form-group">
                 <label for="visualize-file">Obraz do wizualizacji (PNG/JPG):</label>
@@ -500,6 +618,44 @@
         margin-bottom: 8px;
         font-size: 0.9rem;
         color: #4a5568;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+    }
+
+    .capacity-info {
+        background-color: #ebf8ff;
+        border: 1px solid #bee3f8;
+        color: #2c5282;
+        padding: 10px 14px;
+        border-radius: 8px;
+        font-size: 0.9rem;
+        margin-bottom: 20px;
+    }
+
+    .capacity-info--pending {
+        background-color: #f7fafc;
+        border-color: #e2e8f0;
+        color: #718096;
+    }
+
+    .capacity-info--error {
+        background-color: #fff5f5;
+        border-color: #feb2b2;
+        color: #9b2c2c;
+    }
+
+    .char-counter {
+        font-size: 0.8rem;
+        font-weight: 500;
+        color: #718096;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .char-counter--over {
+        color: #c53030;
+        font-weight: 700;
     }
 
     .input-text, .input-file {
@@ -586,6 +742,18 @@
         background-color: #ebf8ff;
         color: #2b6cb0;
         border-left: 4px solid #4299e1;
+    }
+
+    .hint {
+        margin: -8px 0 16px;
+        font-size: 0.8rem;
+        color: #64748b; /* slate-500, ~5.7:1 on white — meets WCAG AA */
+        line-height: 1.45;
+    }
+
+    .hint--result {
+        margin: 14px 0 0;
+        text-align: center;
     }
 
     .result-card {

--- a/watermark-service-py/.dockerignore
+++ b/watermark-service-py/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+venv/
+test_env/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+tests/
+*.md
+.git/
+.gitignore

--- a/watermark-service-py/Dockerfile
+++ b/watermark-service-py/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements-runtime.txt .
+# `--no-deps invisible-watermark` skips the upstream torch dep so we don't pull
+# both the CPU-only torch wheel (above) AND torch GPU build. PyWavelets and
+# opencv-python-headless (the other transitives) are pinned in requirements-runtime.txt.
+RUN pip install --no-cache-dir -r requirements-runtime.txt \
+    && pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.5.1+cpu \
+    && pip install --no-cache-dir --no-deps invisible-watermark==0.2.0
+
+COPY app/ ./app/
+
+# Drop root: uvicorn binds the unprivileged port 8082, so no need for CAP_NET_BIND.
+RUN useradd --create-home --uid 10001 app && chown -R app:app /app
+USER app
+
+EXPOSE 8082
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://localhost:8082/health || exit 1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8082"]

--- a/watermark-service-py/README.md
+++ b/watermark-service-py/README.md
@@ -1,0 +1,116 @@
+# watermark-service (Python)
+
+Production replacement for the Java `watermark-service`. Uses [`invisible-watermark`](https://github.com/ShieldMnt/invisible-watermark) (DwtDctSvd mode) for the actual frequency-domain embedding, with an AES-GCM crypto layer on top so the payload is **encrypted and authenticated** before it ever reaches the algorithm.
+
+## Run (in compose)
+
+```
+docker compose up -d --build watermark-service
+```
+
+Eureka name: `WATERMARK-SERVICE`. Port: `8082`. Drop-in for the Java service — clients (GUI, watermark-client, Feign) need no changes.
+
+## Endpoints
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| POST | `/api/watermark/embed` | JWT | multipart `image`+`text`, returns PNG body + `X-Image-Category/Label/Confidence` + `X-Max-Text-Bytes` headers |
+| POST | `/api/watermark/detect` | JWT | returns `{"watermarked", "ownerIdentity", "version"}` |
+| POST | `/api/watermark/extract` | JWT | returns `{"ownerIdentity", "text"}`; 403 on owner mismatch |
+| POST | `/api/watermark/visualize` | JWT | returns heatmap PNG of pixel diff from sentinel embed |
+| POST | `/api/watermark/capacity` | JWT | returns `{"maxTextBytes", "minImageWidth", "minImageHeight", "imageWidth", "imageHeight", "imageOk"}` |
+| GET  | `/health` | none | `{"status":"UP"}` |
+| GET  | `/docs` | none | Swagger UI |
+
+## User contract: PNG in, PNG out, do not recompress
+
+The watermark hides bits in DCT coefficients. **JPEG compression also operates on
+DCT** and aggressively rounds the same coefficients the watermark lives in, so any
+JPEG re-encode (even Q=95) likely destroys it; Q=50 always destroys it. Same for
+screenshots, resizes, filters, or anything that passes through a social-network
+re-encoder (Discord, Twitter, Instagram).
+
+What the end-user MUST do for the watermark to survive:
+
+- **Upload PNG** to `/embed`. JPG input is accepted (the algorithm decodes it) but
+  the watermark has less headroom because the source already lost DCT detail.
+- **Download the result** — `/embed` always returns `Content-Type: image/png`.
+  The GUI saves it as `watermarked_image.png`.
+- **Distribute that exact file** without re-saving, re-compressing, screenshotting,
+  resizing, or uploading anywhere that re-encodes. Keep it PNG, byte-for-byte.
+
+This is a fundamental limitation of the frequency-domain watermarking family; the
+Java implementation has the same constraint. The use case is leak-tracing for
+copies that move untouched (recipient forwards a file as-is) — not DRM against an
+adversary willing to run `convert -quality 50`.
+
+The GUI shows an orange warning on the embed page and on the result card; the
+input filter on the embed tab restricts to `accept="image/png"`. Detect/Extract/
+Visualize keep `image/png, image/jpeg` so users can confirm "yes this JPG copy
+lost the watermark" rather than getting a silent file-picker rejection.
+
+## Security model
+
+- Payload is `owner|text` UTF-8, **encrypted with AES-256-GCM** before embedding.
+- Encryption key is derived from `WATERMARK_APP_KEY` (server secret) via SHA-256. Without it nobody can read or forge watermarks.
+- Authentication tag (GCM 128-bit) means tampered or third-party watermarks fail to decrypt and `detect` returns `watermarked=false` — effectively zero false positives.
+- Magic bytes `WMPY` + version byte at envelope head allow fast format rejection and forward-compatible upgrades.
+- **Reed-Solomon ECC** (16 parity bytes, corrects up to 8 byte errors) wraps the encrypted envelope so dwtDctSvd's occasional bit-flips on borderline-sized images don't fail the GCM tag.
+- Wire format: `[ MAGIC(4) | VERSION(1) | NONCE(12) | CIPHERTEXT_AND_TAG(n) ] + ECC_PARITY(16)`. Overhead: **49 bytes**.
+
+## Adaptive capacity
+
+The service picks the largest watermark capacity an image can carry. Two tiers:
+
+| Image min side | `length_bits` | Total bytes | Usable text (after envelope + `owner-id|`) |
+|---|---|---|---|
+| **≥1600 px** | 1024 | 128 | **~71 chars** |
+| **≥1200 px** | 768  | 96  | **~39 chars** |
+| <1200 px | — | — | rejected |
+
+Tiers were calibrated empirically against random-pixel images (worst case for dwtDctSvd); real photographs typically work at slightly smaller dimensions but the floors above are guaranteed-safe.
+
+- `POST /api/watermark/capacity` reports the picked tier + character budget for any uploaded image.
+- `/embed` response includes `X-Max-Text-Bytes` and `X-Watermark-Length-Bits` headers.
+- `/detect` tries each known length until one decrypts → no need to remember which tier was used.
+- The GUI uses `/capacity` for a live byte-counter near the text input and disables submit for too-small images.
+
+## Configuration
+
+Configuration flows from three sources, in priority order:
+
+1. **Process environment variables** (set by docker-compose or operator)
+2. **Spring Cloud Config Server** (`http://config-server:8888/watermark-service/default` + `/application/default`)
+3. **Defaults** declared in `app/config.py`
+
+The service polls config-server at startup with exponential backoff (1s → 16s) and degrades gracefully to env+defaults if config-server is unreachable.
+
+### Env vars
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CONFIG_SERVER_URL` | `http://config-server:8888` | Spring Cloud Config Server URL (set empty to disable) |
+| `EUREKA_URL` | `http://eureka-server:8761/eureka/` | Eureka registry |
+| `AUTH_SERVER_URL` | `http://auth-server:8081` | Token validation |
+| `AI_SERVICE_URL` | `http://ai-service:8084` | Classification call from `/embed` |
+| `WATERMARK_APP_KEY` | `local-dev-watermark-secret` | **REQUIRED in production.** Master secret for crypto. Rotate ⇒ all prior watermarks become unreadable. |
+| `INSTANCE_HOSTNAME` | `watermark-service` | Hostname registered with Eureka |
+| `LOG_LEVEL` | `INFO` | Root logger level |
+
+## Local tests
+
+```
+cd watermark-service-py
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+pytest -v
+```
+
+`.venv/` is excluded from the Docker build context via `.dockerignore` — without it the local torch wheels (~5 GB) get copied into the image and overflow disk.
+
+## Roll back to Java backend
+
+```
+git checkout main
+docker compose up -d --build watermark-service
+```

--- a/watermark-service-py/app/ai_client.py
+++ b/watermark-service-py/app/ai_client.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from app.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    category: str
+    label: str
+    confidence: float
+    category_confidence: float
+
+
+_UNKNOWN = ClassificationResult(
+    category="unknown", label="unknown", confidence=0.0, category_confidence=0.0
+)
+
+
+async def classify_or_fallback(
+    settings: Settings,
+    *,
+    image_bytes: bytes,
+    filename: str | None,
+    content_type: str | None,
+    bearer_token: str | None,
+) -> ClassificationResult:
+    """Call ai-service for classification; on any failure return _UNKNOWN.
+
+    Async + split connect/read timeouts so a slow ai-service can't park the
+    event loop. The watermark embed continues regardless of classification.
+    """
+    headers: dict[str, str] = {}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    files = {
+        "file": (filename or "image", image_bytes, content_type or "application/octet-stream"),
+    }
+    timeout = httpx.Timeout(connect=2.0, read=15.0, write=15.0, pool=2.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                f"{settings.ai_service_url}/api/classify",
+                files=files,
+                headers=headers,
+            )
+        if response.status_code != 200:
+            logger.warning(
+                "ai-service returned %s body=%s",
+                response.status_code, response.text[:300],
+            )
+            return _UNKNOWN
+        body = response.json()
+        return ClassificationResult(
+            category=str(body.get("category", "unknown")),
+            label=str(body.get("label", "unknown")),
+            confidence=float(body.get("confidence", 0.0)),
+            category_confidence=float(body.get("categoryConfidence", 0.0)),
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("ai-service classification failed: %s", exc)
+        return _UNKNOWN

--- a/watermark-service-py/app/auth.py
+++ b/watermark-service-py/app/auth.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import re
+
+import httpx
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.config import Settings
+
+logger = logging.getLogger(__name__)
+
+_bearer = HTTPBearer(auto_error=False)
+
+# A principal flows verbatim into the watermark envelope as the owner identity.
+# Reject anything that could break the `owner|text` framing, log injection,
+# or balloon an embedded payload. ASCII identifier characters only.
+_PRINCIPAL_PATTERN = re.compile(r"^[A-Za-z0-9._@-]{1,64}$")
+_DEFAULT_PRINCIPAL = "User"
+
+
+def _401() -> HTTPException:
+    return HTTPException(status_code=401, detail={"error": "Invalid or expired token"})
+
+
+def _503() -> HTTPException:
+    return HTTPException(
+        status_code=503,
+        detail={"error": "Authentication service is currently unavailable"},
+    )
+
+
+def _decode_principal(token: str) -> str:
+    """Mirror Java extractPrincipalFromToken: '{sub}-{userId}', fallback 'User'.
+
+    The auth-server already validated the signature; we only re-parse the body
+    to extract the identifier. Whatever we return goes into the watermark
+    envelope, so it MUST pass `_PRINCIPAL_PATTERN` — anything else falls back
+    to the default principal rather than being embedded verbatim.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return _DEFAULT_PRINCIPAL
+        payload_segment = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_segment))
+        sub = payload.get("sub")
+        user_id = payload.get("userId")
+        if isinstance(sub, str) and user_id is not None:
+            candidate = f"{sub}-{user_id}"
+            if _PRINCIPAL_PATTERN.fullmatch(candidate):
+                return candidate
+            logger.warning("JWT principal failed sanitization: %r", candidate)
+    except (ValueError, json.JSONDecodeError, binascii.Error) as exc:
+        logger.debug("Could not parse JWT payload: %s", exc)
+    return _DEFAULT_PRINCIPAL
+
+
+def require_principal(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+) -> str:
+    if credentials is None or not credentials.credentials:
+        raise _401()
+
+    settings: Settings = request.app.state.settings
+    token = credentials.credentials
+
+    try:
+        with httpx.Client(timeout=httpx.Timeout(connect=2.0, read=5.0, write=5.0, pool=2.0)) as client:
+            response = client.post(
+                f"{settings.auth_server_url}/auth/validate",
+                params={"token": token},
+            )
+    except httpx.HTTPError as exc:
+        logger.error("auth-server unreachable: %s", exc)
+        raise _503()
+
+    if response.status_code != 200:
+        raise _401()
+    try:
+        body = response.json()
+    except ValueError:
+        raise _401()
+    # Strict identity — anything other than literal JSON `true` is a rejection,
+    # so a future auth-server schema change (e.g. `{"valid": true}`) fails closed
+    # instead of silently accepting unrelated truthy bodies.
+    if body is not True:
+        raise _401()
+
+    return _decode_principal(token)

--- a/watermark-service-py/app/config.py
+++ b/watermark-service-py/app/config.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import httpx
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+APPLICATION_NAME = "watermark-service"
+
+# Public-knowledge fallback used in dev/compose. Refusing to boot prod with this
+# value keeps a misconfigured deploy from producing forgeable watermarks.
+DEFAULT_DEV_APP_KEY = "local-dev-watermark-secret"
+
+
+class InsecureDefaultAppKeyError(RuntimeError):
+    """Raised when WATERMARK_APP_KEY is the public dev default and dev-mode is off."""
+
+
+class Settings(BaseSettings):
+    """Runtime configuration.
+
+    Precedence (highest first):
+      1. Process environment variables
+      2. Properties merged from Spring Cloud Config Server (application + watermark-service)
+      3. Defaults declared below
+    """
+
+    config_server_url: str = "http://config-server:8888"
+    eureka_url: str = "http://eureka-server:8761/eureka/"
+    auth_server_url: str = "http://auth-server:8081"
+    ai_service_url: str = "http://ai-service:8084"
+    watermark_app_key: str = DEFAULT_DEV_APP_KEY
+    log_level: str = "INFO"
+    instance_hostname: str = "watermark-service"
+
+    model_config = SettingsConfigDict(env_file=None, case_sensitive=False)
+
+
+# Spring's flat property keys → our snake_case Settings field names.
+_PROPERTY_KEY_MAP: dict[str, str] = {
+    "eureka.client.serviceurl.defaultzone": "eureka_url",
+    "watermark.app-key": "watermark_app_key",
+    "auth-server.url": "auth_server_url",
+    "ai-service.url": "ai_service_url",
+    "logging.level.root": "log_level",
+}
+
+_RETRY_DELAYS_S: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0)
+
+
+def _fetch_property_sources(config_server_url: str, profile: str = "default") -> dict[str, str]:
+    """Pull merged properties for `application` + this service from config-server.
+
+    Returns flattened {dotted.key: stringified_value}. On any failure returns {} —
+    we want the service to keep booting on legacy defaults rather than crash-loop
+    when config-server is reachable-but-broken or genuinely down.
+    """
+    base = config_server_url.rstrip("/")
+    paths = [f"/application/{profile}", f"/{APPLICATION_NAME}/{profile}"]
+
+    merged: dict[str, str] = {}
+    for path in paths:
+        url = f"{base}{path}"
+        body = _fetch_with_retry(url)
+        if body is None:
+            # One profile being unreachable shouldn't lose properties from the
+            # other — keep merging what we got.
+            continue
+        for source in reversed(body.get("propertySources", [])):
+            for key, value in (source.get("source") or {}).items():
+                merged[key.lower()] = str(value)
+    return merged
+
+
+def _fetch_with_retry(url: str) -> dict | None:
+    last_error: Exception | None = None
+    for delay in _RETRY_DELAYS_S:
+        try:
+            with httpx.Client(timeout=5.0) as client:
+                response = client.get(url)
+            if response.status_code == 200:
+                return response.json()
+            last_error = RuntimeError(f"HTTP {response.status_code}")
+        except httpx.HTTPError as exc:
+            last_error = exc
+        logger.info("config-server %s not ready (%s); retrying in %.0fs", url, last_error, delay)
+        time.sleep(delay)
+    logger.warning("Giving up on config-server %s: %s", url, last_error)
+    return None
+
+
+_MAX_PLACEHOLDER_PASSES = 16
+
+
+def _resolve_property(raw: str) -> str:
+    """Spring config values often contain ${VAR:default} placeholders. Resolve them
+    against the process environment so e.g. ${EUREKA_URL:...} respects the same env
+    var the docker-compose file sets.
+
+    Cap iteration count to defang cyclic placeholders (${A} where A=${A}).
+    """
+    if "${" not in raw:
+        return raw
+    result = raw
+    for _ in range(_MAX_PLACEHOLDER_PASSES):
+        if "${" not in result:
+            return result
+        start = result.index("${")
+        end = result.find("}", start)
+        if end == -1:
+            break
+        token = result[start + 2 : end]
+        name, _, default = token.partition(":")
+        value = os.environ.get(name, default)
+        result = result[:start] + value + result[end + 1 :]
+    logger.warning("Placeholder resolution gave up after %d passes: %r", _MAX_PLACEHOLDER_PASSES, raw)
+    return result
+
+
+def _apply_config_overrides(properties: dict[str, str]) -> None:
+    """Project relevant Spring properties onto our env BEFORE Settings reads them,
+    so env-var precedence (set by the operator) naturally wins."""
+    for spring_key, settings_field in _PROPERTY_KEY_MAP.items():
+        if spring_key not in properties:
+            continue
+        env_name = settings_field.upper()
+        if env_name in os.environ:
+            continue  # operator-provided env wins over config-server
+        os.environ[env_name] = _resolve_property(properties[spring_key])
+
+
+def get_settings() -> Settings:
+    """Bootstrap: fetch from config-server (if configured) then build Settings."""
+    config_server_url = os.environ.get("CONFIG_SERVER_URL", "http://config-server:8888")
+    if config_server_url:
+        properties = _fetch_property_sources(config_server_url)
+        if properties:
+            _apply_config_overrides(properties)
+            logger.info(
+                "Loaded %d properties from config-server %s",
+                len(properties), config_server_url,
+            )
+    settings = Settings()
+    _enforce_app_key_safety(settings)
+    return settings
+
+
+def _enforce_app_key_safety(settings: Settings) -> None:
+    if settings.watermark_app_key != DEFAULT_DEV_APP_KEY:
+        return
+    if os.environ.get("WATERMARK_DEV_MODE", "").lower() == "true":
+        logger.warning(
+            "WATERMARK_APP_KEY is the public dev default. "
+            "Running because WATERMARK_DEV_MODE=true — do NOT use in production."
+        )
+        return
+    raise InsecureDefaultAppKeyError(
+        "WATERMARK_APP_KEY is set to the public dev default. "
+        "Set a real secret via env or config-server, or set WATERMARK_DEV_MODE=true "
+        "to acknowledge the risk in a development environment."
+    )

--- a/watermark-service-py/app/crypto.py
+++ b/watermark-service-py/app/crypto.py
@@ -1,0 +1,110 @@
+"""AES-GCM envelope + Reed-Solomon ECC for watermark payloads.
+
+Pipeline at embed time:
+    1. Build plaintext: f"{owner}|{text}".encode("utf-8")
+    2. Encrypt with AES-256-GCM (key derived from WATERMARK_APP_KEY)
+    3. Prepend magic+version+nonce → "envelope"
+    4. Append Reed-Solomon parity bytes → "ECC-protected envelope"
+    5. Pad with NUL up to length_bits/8 bytes
+    6. Hand off to invisible-watermark library
+
+Reverse on detect. The ECC layer recovers from up to ECC_PARITY_BYTES/2 byte errors
+introduced by the frequency-domain watermarking (which can flip ~0–3 bits on
+borderline-size images — without ECC the GCM tag would reject everything).
+
+Wire format (innermost first):
+    plaintext   = owner | '|' | text                                (UTF-8)
+    envelope    = MAGIC(4) | VERSION(1) | NONCE(12) | CIPHERTEXT_AND_TAG(n)
+    protected   = envelope | ECC_PARITY(16)
+    embedded    = protected.ljust(length_bits // 8, b'\\x00')
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+
+import reedsolo
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_MAGIC = b"WMPY"
+_VERSION = b"\x02"  # bumped from v1 (no ECC) to v2 (ECC-wrapped)
+_NONCE_LEN = 12
+_TAG_LEN = 16
+HEADER_LEN = len(_MAGIC) + len(_VERSION) + _NONCE_LEN  # 17
+
+# Reed-Solomon parity bytes. Corrects up to ECC_PARITY_BYTES / 2 byte errors.
+# Calibrated at 16 bytes (= 8 corrected byte errors) so even threshold-sized images
+# with unlucky pixel distributions round-trip reliably across seeds. Lower values
+# (8) leaked occasional failures at the 768-bit tier boundary.
+ECC_PARITY_BYTES = 16
+
+# Total non-plaintext overhead consumed per embedded watermark.
+ENVELOPE_OVERHEAD = HEADER_LEN + _TAG_LEN + ECC_PARITY_BYTES  # 17 + 16 + 16 = 49 bytes
+
+
+class CryptoError(Exception):
+    """Raised when an envelope is malformed, ECC fails, or authentication fails."""
+
+
+@dataclass(frozen=True)
+class DecodedEnvelope:
+    owner: str
+    text: str
+
+
+_rs_codec = reedsolo.RSCodec(ECC_PARITY_BYTES)
+
+
+def _derive_key(app_key: str) -> bytes:
+    if not app_key:
+        raise ValueError("WATERMARK_APP_KEY must not be empty")
+    return hashlib.sha256(("watermark-app:" + app_key).encode("utf-8")).digest()
+
+
+def seal(owner: str, text: str, *, app_key: str) -> bytes:
+    if "|" in owner:
+        raise ValueError("owner identifier must not contain '|'")
+    plaintext = f"{owner}|{text}".encode("utf-8")
+    key = _derive_key(app_key)
+    nonce = os.urandom(_NONCE_LEN)
+    aad = _MAGIC + _VERSION
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
+    envelope = _MAGIC + _VERSION + nonce + ciphertext
+    return bytes(_rs_codec.encode(envelope))
+
+
+def unseal(blob: bytes, *, app_key: str) -> DecodedEnvelope:
+    if len(blob) < HEADER_LEN + _TAG_LEN + ECC_PARITY_BYTES:
+        raise CryptoError("envelope too short")
+    try:
+        envelope_bytes, _, _ = _rs_codec.decode(blob)
+    except reedsolo.ReedSolomonError as exc:
+        raise CryptoError("ECC failed — too many corrupted bytes") from exc
+    envelope = bytes(envelope_bytes)
+    if envelope[: len(_MAGIC)] != _MAGIC:
+        raise CryptoError("magic mismatch")
+    if envelope[len(_MAGIC) : len(_MAGIC) + 1] != _VERSION:
+        raise CryptoError("unsupported envelope version")
+    nonce = envelope[len(_MAGIC) + 1 : HEADER_LEN]
+    ciphertext = envelope[HEADER_LEN:]
+    key = _derive_key(app_key)
+    aad = _MAGIC + _VERSION
+    try:
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, aad)
+    except InvalidTag as exc:
+        raise CryptoError("authentication failed — wrong key or tampered envelope") from exc
+    text = plaintext.decode("utf-8")
+    if "|" not in text:
+        raise CryptoError("envelope plaintext missing owner separator")
+    owner, _, body = text.partition("|")
+    if not owner:
+        raise CryptoError("envelope plaintext has empty owner")
+    return DecodedEnvelope(owner=owner, text=body)
+
+
+def max_text_bytes(length_bits: int, owner: str) -> int:
+    """How many UTF-8 bytes of user text fit, given the watermark capacity and owner."""
+    owner_bytes = len(owner.encode("utf-8")) + 1  # owner + '|'
+    return max(0, length_bits // 8 - ENVELOPE_OVERHEAD - owner_bytes)

--- a/watermark-service-py/app/eureka.py
+++ b/watermark-service-py/app/eureka.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+import socket
+
+from py_eureka_client import eureka_client
+
+from app.config import Settings
+
+logger = logging.getLogger(__name__)
+
+_INSTANCE_PORT = 8082
+
+
+async def register(settings: Settings) -> None:
+    if not settings.eureka_url:
+        logger.info("EUREKA_URL empty — skipping Eureka registration")
+        return
+    host = settings.instance_hostname or socket.gethostname()
+    base_url = f"http://{host}:{_INSTANCE_PORT}"
+    try:
+        await eureka_client.init_async(
+            eureka_server=settings.eureka_url,
+            app_name="WATERMARK-SERVICE",
+            instance_port=_INSTANCE_PORT,
+            instance_host=host,
+            health_check_url=f"{base_url}/health",
+            status_page_url=f"{base_url}/health",
+            renewal_interval_in_secs=30,
+            duration_in_secs=90,
+        )
+        logger.info("Registered with Eureka at %s as WATERMARK-SERVICE", settings.eureka_url)
+    except Exception as exc:
+        logger.error("Eureka registration failed: %s", exc)
+
+
+async def deregister() -> None:
+    try:
+        await eureka_client.stop_async()
+        logger.info("Deregistered from Eureka")
+    except Exception as exc:
+        logger.warning("Eureka deregister failed: %s", exc)

--- a/watermark-service-py/app/main.py
+++ b/watermark-service-py/app/main.py
@@ -1,0 +1,53 @@
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from app.config import Settings, get_settings
+from app.eureka import deregister, register
+from app.routes import router as watermark_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings: Settings = app.state.settings
+    await register(settings)
+    try:
+        yield
+    finally:
+        await deregister()
+
+
+def create_app() -> FastAPI:
+    # Configure logging before get_settings so the config-server bootstrap is visible.
+    # Re-applied after settings load in case LOG_LEVEL differs from INFO.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    settings = get_settings()
+    logging.getLogger().setLevel(getattr(logging, settings.log_level.upper(), logging.INFO))
+    app = FastAPI(
+        title="watermark-service",
+        version="0.2.0-py",
+        lifespan=lifespan,
+    )
+    app.state.settings = settings
+
+    @app.exception_handler(HTTPException)
+    async def _http_exception_handler(request: Request, exc: HTTPException):
+        if isinstance(exc.detail, dict):
+            return JSONResponse(status_code=exc.status_code, content=exc.detail)
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    app.include_router(watermark_router)
+
+    @app.get("/health")
+    def health():
+        return {"status": "UP"}
+
+    return app
+
+
+app = create_app()

--- a/watermark-service-py/app/routes.py
+++ b/watermark-service-py/app/routes.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import Response
+
+from app.ai_client import classify_or_fallback
+from app.auth import require_principal
+from app.config import Settings
+from app.watermark import (
+    capacity_report,
+    detect_text,
+    embed_text,
+    visualize,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/watermark", tags=["Watermark"])
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+# 25 MB matches the multipart limit in the config-server-served application.yaml.
+_MAX_IMAGE_BYTES = 25 * 1024 * 1024
+_MAX_TEXT_BYTES = 4096
+
+
+def _settings(request: Request) -> Settings:
+    return request.app.state.settings
+
+
+def _bearer_from_request(request: Request) -> str | None:
+    header = request.headers.get("authorization", "")
+    if header.lower().startswith("bearer "):
+        return header[7:]
+    return None
+
+
+def _read_png(image_bytes: bytes) -> None:
+    """Reject non-PNG uploads on the embed path so the GUI's PNG-only contract
+    is enforced at the server boundary, not just by the file-picker filter."""
+    if len(image_bytes) > _MAX_IMAGE_BYTES:
+        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+    if not image_bytes.startswith(_PNG_MAGIC):
+        raise HTTPException(
+            400,
+            detail="Embed accepts PNG only. JPG/WebP destroy the watermark on the very first re-encode.",
+        )
+
+
+@router.post("/embed")
+async def embed(
+    request: Request,
+    image: Annotated[UploadFile, File()],
+    text: Annotated[str, Form()],
+    principal: Annotated[str, Depends(require_principal)],
+):
+    if not text or not text.strip():
+        raise HTTPException(400, detail="text must not be blank")
+    if len(text.encode("utf-8")) > _MAX_TEXT_BYTES:
+        raise HTTPException(413, detail=f"Text too large (max {_MAX_TEXT_BYTES} bytes)")
+
+    settings = _settings(request)
+    image_bytes = await image.read()
+    _read_png(image_bytes)
+
+    report = capacity_report(image_bytes, owner=principal)
+    if not report.image_ok:
+        raise HTTPException(
+            400,
+            detail=(
+                f"Image too small ({report.image_width}x{report.image_height}). "
+                f"Minimum {report.min_image_width}x{report.min_image_height} for the smallest watermark tier."
+            ),
+        )
+    if len(text.encode("utf-8")) > report.max_text_bytes:
+        raise HTTPException(
+            400,
+            detail=f"Text too long: max {report.max_text_bytes} bytes for this image and owner.",
+        )
+
+    classification = await classify_or_fallback(
+        settings,
+        image_bytes=image_bytes,
+        filename=image.filename,
+        content_type=image.content_type,
+        bearer_token=_bearer_from_request(request),
+    )
+
+    try:
+        result = embed_text(
+            image_bytes,
+            text,
+            owner=principal,
+            app_key=settings.watermark_app_key,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, detail=str(exc))
+    except RuntimeError as exc:
+        # embed verification failed at every tier — image content is
+        # pathological for the watermark; user can try a larger image.
+        logger.warning("Embed verification failed for principal=%s: %s", principal, exc)
+        raise HTTPException(422, detail=str(exc))
+
+    return Response(
+        content=result.png_bytes,
+        media_type="image/png",
+        headers={
+            "X-Image-Category": classification.category,
+            "X-Image-Label": classification.label,
+            "X-Image-Confidence": str(classification.confidence),
+            "X-Image-Category-Confidence": str(classification.category_confidence),
+            "X-Max-Text-Bytes": str(report.max_text_bytes),
+            "X-Watermark-Length-Bits": str(report.length_bits),
+        },
+    )
+
+
+@router.post("/detect")
+async def detect(
+    request: Request,
+    image: Annotated[UploadFile, File()],
+    principal: Annotated[str, Depends(require_principal)],
+):
+    settings = _settings(request)
+    image_bytes = await image.read()
+    if len(image_bytes) > _MAX_IMAGE_BYTES:
+        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+    detection = detect_text(image_bytes, app_key=settings.watermark_app_key)
+    return {
+        "watermarked": detection.watermarked,
+        "ownerIdentity": detection.owner_identity,
+        "version": 1 if detection.watermarked else None,
+        "lengthBits": detection.length_bits,
+    }
+
+
+@router.post("/extract")
+async def extract(
+    request: Request,
+    image: Annotated[UploadFile, File()],
+    principal: Annotated[str, Depends(require_principal)],
+):
+    settings = _settings(request)
+    image_bytes = await image.read()
+    if len(image_bytes) > _MAX_IMAGE_BYTES:
+        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+    detection = detect_text(image_bytes, app_key=settings.watermark_app_key)
+    if not detection.watermarked:
+        raise HTTPException(400, detail="No watermark found in this image")
+    if detection.owner_identity != principal:
+        raise HTTPException(403, detail="Requester is not allowed to read this watermark")
+    return {"ownerIdentity": detection.owner_identity, "text": detection.text}
+
+
+@router.post("/visualize")
+async def visualize_endpoint(
+    request: Request,
+    image: Annotated[UploadFile, File()],
+    principal: Annotated[str, Depends(require_principal)],
+):
+    settings = _settings(request)
+    image_bytes = await image.read()
+    if len(image_bytes) > _MAX_IMAGE_BYTES:
+        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+    try:
+        heatmap = visualize(image_bytes, app_key=settings.watermark_app_key)
+    except ValueError as exc:
+        raise HTTPException(400, detail=str(exc))
+    return Response(content=heatmap, media_type="image/png")
+
+
+@router.post("/capacity")
+async def capacity(
+    request: Request,
+    image: Annotated[UploadFile, File()],
+    principal: Annotated[str, Depends(require_principal)],
+):
+    image_bytes = await image.read()
+    if len(image_bytes) > _MAX_IMAGE_BYTES:
+        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+    report = capacity_report(image_bytes, owner=principal)
+    return {
+        "maxTextBytes": report.max_text_bytes,
+        "minImageWidth": report.min_image_width,
+        "minImageHeight": report.min_image_height,
+        "imageWidth": report.image_width,
+        "imageHeight": report.image_height,
+        "imageOk": report.image_ok,
+        "lengthBits": report.length_bits,
+    }

--- a/watermark-service-py/app/watermark.py
+++ b/watermark-service-py/app/watermark.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+from imwatermark import WatermarkDecoder, WatermarkEncoder
+
+from app import crypto
+
+logger = logging.getLogger(__name__)
+
+# Adaptive tiers: pick the largest watermark capacity the image can carry reliably.
+# Empirically calibrated against random-pixel images (worst-case for dwtDctSvd).
+# Real photographs typically tolerate equal or smaller dimensions.
+#
+# Each tier requires (min_short_side, min_long_side) — so a 1920×1080 landscape
+# screenshot picks the same tier as 1080×1920 portrait. The asymmetric thresholds
+# reflect the empirical finding that dwtDctSvd's bit error rate depends roughly on
+# pixel-per-bit density rather than a square minimum.
+#
+# Capacity after AES-GCM envelope + Reed-Solomon parity:
+#   1024 bits → ~71 chars of text (after owner like "alice-7|" ~8 bytes)
+#   768 bits  → ~39 chars
+#
+# Embed verifies the round-trip and falls back to the next smaller tier if the
+# library's bit-flips overwhelm even Reed-Solomon, so what we promise here is the
+# *typical* outcome; the actual tier used is reported back in response headers.
+TIERS: tuple[tuple[int, int, int], ...] = (
+    # (min_short_side, min_long_side, length_bits)
+    (1080, 1600, 1024),  # FHD landscape/portrait, 1600×1600+, modern phone photos
+    (1024, 1024, 768),   # 1024×1024+ (square OK), photos that didn't qualify for tier A
+)
+
+KNOWN_LENGTHS_BITS: tuple[int, ...] = tuple(bits for _, _, bits in TIERS)
+MIN_SHORT_SIDE: int = TIERS[-1][0]
+MIN_LONG_SIDE: int = TIERS[-1][1]
+
+
+@dataclass(frozen=True)
+class WatermarkResult:
+    png_bytes: bytes
+
+
+@dataclass(frozen=True)
+class CapacityReport:
+    max_text_bytes: int
+    min_image_width: int
+    min_image_height: int
+    image_ok: bool
+    image_width: int
+    image_height: int
+    length_bits: int  # 0 when image is below the minimum tier
+
+
+def _decode_png(image_bytes: bytes) -> np.ndarray:
+    """Decode image bytes to a BGR ndarray, honoring EXIF orientation.
+
+    cv2.imdecode ignores EXIF rotation; a portrait JPEG with an orientation tag
+    decodes as landscape pixels, which throws off our tier selector (which
+    looks at width vs height). Pre-apply Pillow's `exif_transpose` so the
+    pixel data matches what the user sees.
+    """
+    from io import BytesIO
+
+    from PIL import Image, ImageOps
+
+    try:
+        with Image.open(BytesIO(image_bytes)) as pil_img:
+            oriented = ImageOps.exif_transpose(pil_img).convert("RGB")
+    except Exception as exc:  # PIL.UnidentifiedImageError, OSError, etc.
+        raise ValueError(f"Could not decode image bytes: {exc}") from exc
+    rgb_array = np.asarray(oriented)
+    return cv2.cvtColor(rgb_array, cv2.COLOR_RGB2BGR)
+
+
+def _encode_png(bgr: np.ndarray) -> bytes:
+    ok, buf = cv2.imencode(".png", bgr, [cv2.IMWRITE_PNG_COMPRESSION, 9])
+    if not ok:
+        raise RuntimeError("Could not encode PNG")
+    return buf.tobytes()
+
+
+def _pack(payload: bytes, length_bits: int) -> bytes:
+    target_bytes = length_bits // 8
+    if len(payload) > target_bytes:
+        raise ValueError(
+            f"Encrypted payload too long: {len(payload)} bytes, capacity {target_bytes} bytes "
+            f"(at {length_bits}-bit watermark)"
+        )
+    return payload.ljust(target_bytes, b"\x00")
+
+
+def _unpack(raw: bytes) -> bytes:
+    return raw.rstrip(b"\x00")
+
+
+def _tiers_for_image(width: int, height: int) -> list[int]:
+    """Return all tiers an image qualifies for, largest-capacity first.
+
+    Empty list ⇒ image too small for any tier.
+    """
+    short = min(width, height)
+    long_side = max(width, height)
+    return [
+        bits
+        for min_short, min_long, bits in TIERS
+        if short >= min_short and long_side >= min_long
+    ]
+
+
+def select_length_bits(width: int, height: int) -> int:
+    """Pick the largest watermark capacity this image can carry. Raises if too small."""
+    tiers = _tiers_for_image(width, height)
+    if not tiers:
+        raise ValueError(
+            f"Image too small: {width}x{height}, need at least "
+            f"{MIN_SHORT_SIDE}x{MIN_LONG_SIDE} (short × long side) for any watermark capacity"
+        )
+    return tiers[0]
+
+
+def capacity_report(image_bytes: bytes, *, owner: str) -> CapacityReport:
+    bgr = _decode_png(image_bytes)
+    height, width = bgr.shape[:2]
+    tiers = _tiers_for_image(width, height)
+    if not tiers:
+        return CapacityReport(
+            max_text_bytes=0,
+            min_image_width=MIN_SHORT_SIDE,
+            min_image_height=MIN_LONG_SIDE,
+            image_ok=False,
+            image_width=width,
+            image_height=height,
+            length_bits=0,
+        )
+    length_bits = tiers[0]
+    return CapacityReport(
+        max_text_bytes=crypto.max_text_bytes(length_bits, owner),
+        min_image_width=MIN_SHORT_SIDE,
+        min_image_height=MIN_LONG_SIDE,
+        image_ok=True,
+        image_width=width,
+        image_height=height,
+        length_bits=length_bits,
+    )
+
+
+def _embed_at_tier(bgr: np.ndarray, sealed: bytes, length_bits: int) -> bytes:
+    payload = _pack(sealed, length_bits)
+    encoder = WatermarkEncoder()
+    encoder.set_watermark("bytes", payload)
+    watermarked = encoder.encode(bgr, "dwtDctSvd")
+    return _encode_png(watermarked)
+
+
+def _verify_roundtrip(png_bytes: bytes, length_bits: int, expected: crypto.DecodedEnvelope, *, app_key: str) -> bool:
+    """Decode + decrypt the embedded image to confirm the watermark survives PNG round-trip
+    AND ECC+GCM produce the original payload. Catches the (rare) cases where even
+    Reed-Solomon can't fix the library's bit-flips.
+
+    Any exception during decode (imwatermark internals can raise IndexError on
+    short reads, etc.) counts as verification failure so the caller falls back
+    to the next tier instead of bubbling a 500."""
+    try:
+        bgr = _decode_png(png_bytes)
+        decoder = WatermarkDecoder("bytes", length_bits)
+        raw = _unpack(decoder.decode(bgr, "dwtDctSvd"))
+        decoded = crypto.unseal(raw, app_key=app_key)
+    except (crypto.CryptoError, Exception) as exc:  # noqa: BLE001 — intentional broad catch
+        if not isinstance(exc, crypto.CryptoError):
+            logger.debug("Roundtrip verification raised %s: %s", type(exc).__name__, exc)
+        return False
+    return decoded.owner == expected.owner and decoded.text == expected.text
+
+
+def embed_text(
+    image_bytes: bytes,
+    text: str,
+    *,
+    owner: str,
+    app_key: str,
+) -> WatermarkResult:
+    bgr = _decode_png(image_bytes)
+    height, width = bgr.shape[:2]
+    candidate_tiers = _tiers_for_image(width, height)
+    if not candidate_tiers:
+        raise ValueError(
+            f"Image too small: {width}x{height}, need at least "
+            f"{MIN_SHORT_SIDE}x{MIN_LONG_SIDE} (short × long side)"
+        )
+
+    sealed = crypto.seal(owner, text, app_key=app_key)
+    expected = crypto.DecodedEnvelope(owner=owner, text=text)
+
+    last_error: Exception | None = None
+    for length_bits in candidate_tiers:
+        try:
+            png_bytes = _embed_at_tier(bgr, sealed, length_bits)
+        except ValueError as exc:
+            # text too long for THIS tier — try the next (smaller) one, but
+            # remember the error in case all tiers are too small for the text
+            last_error = exc
+            continue
+        if _verify_roundtrip(png_bytes, length_bits, expected, app_key=app_key):
+            return WatermarkResult(png_bytes=png_bytes)
+        # round-trip verification failed — fall back to next smaller tier
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError(
+        "Embed verification failed at every tier. The image may have unusual content; "
+        "try a larger or differently-shaped image."
+    )
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    watermarked: bool
+    owner_identity: str | None
+    text: str | None
+    length_bits: int | None
+
+
+def detect_text(image_bytes: bytes, *, app_key: str) -> DetectionResult:
+    """Try each known length until one decrypts. Wrong length → GCM tag rejects."""
+    bgr = _decode_png(image_bytes)
+    for length_bits in KNOWN_LENGTHS_BITS:
+        decoder = WatermarkDecoder("bytes", length_bits)
+        raw = _unpack(decoder.decode(bgr, "dwtDctSvd"))
+        try:
+            envelope = crypto.unseal(raw, app_key=app_key)
+        except crypto.CryptoError:
+            continue
+        return DetectionResult(
+            watermarked=True,
+            owner_identity=envelope.owner,
+            text=envelope.text,
+            length_bits=length_bits,
+        )
+    return DetectionResult(watermarked=False, owner_identity=None, text=None, length_bits=None)
+
+
+_SENTINEL_TEXT = "VISUALIZE"
+
+
+def visualize(image_bytes: bytes, *, app_key: str) -> bytes:
+    """Heatmap of |watermarked - input| per pixel as pseudocolor PNG.
+
+    The library may pad the watermarked output to a DCT-aligned size; crop back to source.
+    """
+    bgr = _decode_png(image_bytes)
+    sentinel = embed_text(
+        image_bytes,
+        _SENTINEL_TEXT,
+        owner="visualize",
+        app_key=app_key,
+    )
+    watermarked = _decode_png(sentinel.png_bytes)
+
+    if watermarked.shape != bgr.shape:
+        height, width = bgr.shape[:2]
+        watermarked = watermarked[:height, :width]
+
+    diff = cv2.absdiff(watermarked, bgr)
+    diff_max = diff.max(axis=2).astype(np.uint8)
+
+    peak = int(diff_max.max())
+    if peak > 0:
+        normalized = ((diff_max.astype(np.float32) / peak) * 255.0).astype(np.uint8)
+    else:
+        normalized = diff_max
+
+    heatmap = cv2.applyColorMap(normalized, cv2.COLORMAP_JET)
+    return _encode_png(heatmap)

--- a/watermark-service-py/pytest.ini
+++ b/watermark-service-py/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/watermark-service-py/requirements-runtime.txt
+++ b/watermark-service-py/requirements-runtime.txt
@@ -1,0 +1,12 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+python-multipart==0.0.20
+opencv-python-headless==4.10.0.84
+numpy==1.26.4
+Pillow==11.0.0
+PyWavelets==1.9.0
+py-eureka-client==0.11.13
+httpx==0.28.1
+pydantic-settings==2.7.0
+cryptography==44.0.0
+reedsolo==1.7.0

--- a/watermark-service-py/requirements.txt
+++ b/watermark-service-py/requirements.txt
@@ -1,0 +1,15 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+python-multipart==0.0.20
+invisible-watermark==0.2.0
+opencv-python-headless==4.10.0.84
+numpy==1.26.4
+Pillow==11.0.0
+py-eureka-client==0.11.13
+httpx==0.28.1
+pydantic-settings==2.7.0
+cryptography==44.0.0
+reedsolo==1.7.0
+pytest==8.3.4
+pytest-asyncio==0.25.0
+respx==0.22.0

--- a/watermark-service-py/tests/conftest.py
+++ b/watermark-service-py/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+
+# Tests must not hit a real config-server, real auth-server, or honor any of the
+# operator's local env. Use unconditional assignment so a stray `CONFIG_SERVER_URL`
+# in the developer's shell doesn't make tests reach out to a live instance.
+os.environ["CONFIG_SERVER_URL"] = ""
+os.environ["WATERMARK_APP_KEY"] = "test-app-key-deterministic"
+os.environ["EUREKA_URL"] = ""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app()
+    return TestClient(app)

--- a/watermark-service-py/tests/test_ai_client.py
+++ b/watermark-service-py/tests/test_ai_client.py
@@ -1,0 +1,72 @@
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from app.ai_client import ClassificationResult, classify_or_fallback
+from app.config import Settings
+
+
+SETTINGS = Settings(ai_service_url="http://ai-service:8084")
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_classify_returns_result_on_success():
+    respx.post("http://ai-service:8084/api/classify").mock(
+        return_value=Response(
+            200,
+            json={
+                "category": "dog",
+                "label": "golden retriever",
+                "confidence": 0.05,
+                "categoryConfidence": 0.89,
+                "top3": [],
+            },
+        )
+    )
+    result = await classify_or_fallback(
+        SETTINGS,
+        image_bytes=b"fake-png",
+        filename="img.png",
+        content_type="image/png",
+        bearer_token="abc",
+    )
+    assert result == ClassificationResult(
+        category="dog",
+        label="golden retriever",
+        confidence=0.05,
+        category_confidence=0.89,
+    )
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_classify_returns_unknown_fallback_on_error():
+    respx.post("http://ai-service:8084/api/classify").mock(return_value=Response(500))
+    result = await classify_or_fallback(
+        SETTINGS,
+        image_bytes=b"fake-png",
+        filename="img.png",
+        content_type="image/png",
+        bearer_token="abc",
+    )
+    assert result == ClassificationResult(
+        category="unknown", label="unknown", confidence=0.0, category_confidence=0.0
+    )
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_classify_returns_unknown_when_network_fails():
+    respx.post("http://ai-service:8084/api/classify").mock(side_effect=httpx.ConnectError("boom"))
+    result = await classify_or_fallback(
+        SETTINGS,
+        image_bytes=b"fake-png",
+        filename="img.png",
+        content_type="image/png",
+        bearer_token="abc",
+    )
+    assert result.category == "unknown"
+    assert result.label == "unknown"
+    assert result.confidence == 0.0

--- a/watermark-service-py/tests/test_auth.py
+++ b/watermark-service-py/tests/test_auth.py
@@ -1,0 +1,76 @@
+import base64
+import json
+
+import httpx
+import pytest
+import respx
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from app.auth import require_principal
+from app.config import Settings
+
+
+@pytest.fixture
+def auth_app() -> FastAPI:
+    from app.main import create_app
+    app = create_app()
+    app.state.settings = Settings(auth_server_url="http://auth-server:8081")
+
+    @app.get("/_protected")
+    def protected(principal: str = Depends(require_principal)):
+        return {"principal": principal}
+
+    return app
+
+
+def _jwt_with(sub: str, user_id: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256","typ":"JWT"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"sub": sub, "userId": user_id}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}.signature-placeholder"
+
+
+@respx.mock
+def test_missing_authorization_header_returns_401(auth_app):
+    client = TestClient(auth_app)
+    response = client.get("/_protected")
+    assert response.status_code == 401
+    assert response.json() == {"error": "Invalid or expired token"}
+
+
+@respx.mock
+def test_invalid_token_returns_401(auth_app):
+    respx.post("http://auth-server:8081/auth/validate").mock(
+        return_value=Response(200, json=False)
+    )
+    client = TestClient(auth_app)
+    response = client.get("/_protected", headers={"Authorization": "Bearer bad-token"})
+    assert response.status_code == 401
+    assert response.json() == {"error": "Invalid or expired token"}
+
+
+@respx.mock
+def test_valid_token_extracts_principal(auth_app):
+    respx.post("http://auth-server:8081/auth/validate").mock(
+        return_value=Response(200, json=True)
+    )
+    token = _jwt_with("alice", 42)
+    client = TestClient(auth_app)
+    response = client.get("/_protected", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.json() == {"principal": "alice-42"}
+
+
+@respx.mock
+def test_auth_server_down_returns_503(auth_app):
+    respx.post("http://auth-server:8081/auth/validate").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    token = _jwt_with("alice", 42)
+    client = TestClient(auth_app)
+    response = client.get("/_protected", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 503
+    assert response.json() == {"error": "Authentication service is currently unavailable"}

--- a/watermark-service-py/tests/test_routes.py
+++ b/watermark-service-py/tests/test_routes.py
@@ -1,0 +1,266 @@
+import base64
+import io
+import json
+
+import numpy as np
+import respx
+from PIL import Image
+from httpx import Response
+
+
+def _random_png(width: int, height: int | None = None, seed: int = 0) -> bytes:
+    if height is None:
+        height = width
+    rng = np.random.RandomState(seed)
+    arr = rng.randint(0, 256, (height, width, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _jwt(sub: str, user_id: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256","typ":"JWT"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"sub": sub, "userId": user_id}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}.signature-placeholder"
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_health_returns_ok(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "UP"}
+
+
+@respx.mock
+def test_embed_returns_png_with_classification_and_capacity_headers(client):
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    respx.post("http://ai-service:8084/api/classify").mock(
+        return_value=Response(
+            200,
+            json={
+                "category": "dog",
+                "label": "labrador",
+                "confidence": 0.05,
+                "categoryConfidence": 0.81,
+                "top3": [],
+            },
+        )
+    )
+    token = _jwt("alice", 7)
+    response = client.post(
+        "/api/watermark/embed",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(1600), "image/png")},
+        data={"text": "hello"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["x-image-category"] == "dog"
+    assert response.headers["x-image-label"] == "labrador"
+    assert int(response.headers["x-max-text-bytes"]) > 0
+    assert response.headers["x-watermark-length-bits"] == "1024"
+    assert response.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+@respx.mock
+def test_detect_then_extract_roundtrip(client):
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    respx.post("http://ai-service:8084/api/classify").mock(return_value=Response(500))
+
+    token = _jwt("alice", 7)
+    embed_response = client.post(
+        "/api/watermark/embed",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(1600), "image/png")},
+        data={"text": "hello-world"},
+    )
+    assert embed_response.status_code == 200
+    watermarked_png = embed_response.content
+
+    detect_response = client.post(
+        "/api/watermark/detect",
+        headers=_auth_headers(token),
+        files={"image": ("wm.png", watermarked_png, "image/png")},
+    )
+    assert detect_response.status_code == 200
+    body = detect_response.json()
+    assert body["watermarked"] is True
+    assert body["ownerIdentity"] == "alice-7"
+    assert body["version"] == 1
+    assert body["lengthBits"] == 1024
+
+    extract_response = client.post(
+        "/api/watermark/extract",
+        headers=_auth_headers(token),
+        files={"image": ("wm.png", watermarked_png, "image/png")},
+    )
+    assert extract_response.status_code == 200
+    assert extract_response.json() == {"ownerIdentity": "alice-7", "text": "hello-world"}
+
+
+@respx.mock
+def test_embed_on_smaller_image_picks_lower_tier(client):
+    """A 1024x1024 image only qualifies for the 768-bit tier (1024-bit needs long ≥ 1600)."""
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    respx.post("http://ai-service:8084/api/classify").mock(return_value=Response(500))
+
+    token = _jwt("alice", 7)
+    embed_response = client.post(
+        "/api/watermark/embed",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(1024), "image/png")},
+        data={"text": "medium-sized"},
+    )
+    assert embed_response.status_code == 200
+    assert embed_response.headers["x-watermark-length-bits"] == "768"
+
+    detect_response = client.post(
+        "/api/watermark/detect",
+        headers=_auth_headers(token),
+        files={"image": ("wm.png", embed_response.content, "image/png")},
+    )
+    body = detect_response.json()
+    assert body["watermarked"] is True
+    assert body["lengthBits"] == 768
+
+
+@respx.mock
+def test_embed_fhd_landscape_uses_largest_tier(client):
+    """1920x1080 screenshot should use the 1024-bit tier."""
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    respx.post("http://ai-service:8084/api/classify").mock(return_value=Response(500))
+
+    token = _jwt("alice", 7)
+    response = client.post(
+        "/api/watermark/embed",
+        headers=_auth_headers(token),
+        files={"image": ("fhd.png", _random_png(1920, 1080), "image/png")},
+        data={"text": "fhd screenshot"},
+    )
+    assert response.status_code == 200
+    assert response.headers["x-watermark-length-bits"] == "1024"
+
+
+@respx.mock
+def test_extract_by_wrong_user_returns_403(client):
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    respx.post("http://ai-service:8084/api/classify").mock(return_value=Response(500))
+
+    alice = _jwt("alice", 7)
+    bob = _jwt("bob", 8)
+    embed_response = client.post(
+        "/api/watermark/embed",
+        headers=_auth_headers(alice),
+        files={"image": ("a.png", _random_png(1600), "image/png")},
+        data={"text": "owner-data"},
+    )
+    assert embed_response.status_code == 200
+    extract_response = client.post(
+        "/api/watermark/extract",
+        headers=_auth_headers(bob),
+        files={"image": ("wm.png", embed_response.content, "image/png")},
+    )
+    assert extract_response.status_code == 403
+
+
+@respx.mock
+def test_detect_requires_auth(client):
+    response = client.post(
+        "/api/watermark/detect",
+        files={"image": ("a.png", _random_png(1600), "image/png")},
+    )
+    assert response.status_code == 401
+
+
+@respx.mock
+def test_visualize_requires_auth(client):
+    response = client.post(
+        "/api/watermark/visualize",
+        files={"image": ("a.png", _random_png(1600), "image/png")},
+    )
+    assert response.status_code == 401
+
+
+@respx.mock
+def test_capacity_for_big_image(client):
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    token = _jwt("alice", 7)
+    response = client.post(
+        "/api/watermark/capacity",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(1600), "image/png")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imageOk"] is True
+    assert body["imageWidth"] == 1600
+    assert body["lengthBits"] == 1024
+    assert 70 < body["maxTextBytes"] < 90
+
+
+@respx.mock
+def test_capacity_for_medium_image_picks_lower_tier(client):
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    token = _jwt("alice", 7)
+    response = client.post(
+        "/api/watermark/capacity",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(1024), "image/png")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imageOk"] is True
+    assert body["lengthBits"] == 768
+    assert 30 < body["maxTextBytes"] < 50
+
+
+@respx.mock
+def test_capacity_for_fhd_landscape(client):
+    """1920x1080 reports the 1024-bit tier."""
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    token = _jwt("alice", 7)
+    response = client.post(
+        "/api/watermark/capacity",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(1920, 1080), "image/png")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imageOk"] is True
+    assert body["lengthBits"] == 1024
+    assert body["imageWidth"] == 1920
+    assert body["imageHeight"] == 1080
+
+
+@respx.mock
+def test_capacity_reports_too_small(client):
+    respx.post("http://auth-server:8081/auth/validate").mock(return_value=Response(200, json=True))
+    token = _jwt("alice", 7)
+    response = client.post(
+        "/api/watermark/capacity",
+        headers=_auth_headers(token),
+        files={"image": ("a.png", _random_png(800), "image/png")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imageOk"] is False
+    assert body["lengthBits"] == 0
+
+
+def test_app_boots_when_eureka_unreachable(monkeypatch):
+    monkeypatch.setenv("EUREKA_URL", "http://nonexistent-eureka:9999/eureka/")
+    from importlib import reload
+
+    import app.main
+
+    reload(app.main)
+    test_app = app.main.create_app()
+    from fastapi.testclient import TestClient
+
+    with TestClient(test_app) as test_client:
+        assert test_client.get("/health").status_code == 200

--- a/watermark-service-py/tests/test_watermark.py
+++ b/watermark-service-py/tests/test_watermark.py
@@ -1,0 +1,159 @@
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from app.watermark import (
+    DetectionResult,
+    WatermarkResult,
+    capacity_report,
+    detect_text,
+    embed_text,
+    select_length_bits,
+    visualize,
+)
+
+APP_KEY = "test-app-key-deterministic"
+
+
+def _random_png(width: int, height: int | None = None, seed: int = 42) -> bytes:
+    if height is None:
+        height = width
+    rng = np.random.RandomState(seed)
+    arr = rng.randint(0, 256, (height, width, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def big_image() -> bytes:
+    """1600x1600 — picks the 1024-bit tier (largest capacity)."""
+    return _random_png(1600)
+
+
+@pytest.fixture
+def fhd_landscape() -> bytes:
+    """1920x1080 FHD screenshot — short=1080, long=1920 → 1024-bit tier."""
+    return _random_png(1920, 1080)
+
+
+@pytest.fixture
+def medium_image() -> bytes:
+    """1200x1200 — too narrow for 1024-bit tier (needs long ≥ 1600), falls to 768-bit.
+
+    Note: 1024-bit tier rule is short≥1080 AND long≥1600 — 1200×1200 satisfies the
+    short floor but not the long one, so it picks the 768-bit tier.
+    """
+    return _random_png(1200)
+
+
+def test_embed_then_detect_big_image(big_image):
+    result = embed_text(big_image, "hello world", owner="user-42", app_key=APP_KEY)
+    assert isinstance(result, WatermarkResult)
+    detection = detect_text(result.png_bytes, app_key=APP_KEY)
+    assert isinstance(detection, DetectionResult)
+    assert detection.watermarked is True
+    assert detection.owner_identity == "user-42"
+    assert detection.text == "hello world"
+    assert detection.length_bits == 1024
+
+
+def test_embed_then_detect_medium_image(medium_image):
+    result = embed_text(medium_image, "midsize", owner="u-1", app_key=APP_KEY)
+    detection = detect_text(result.png_bytes, app_key=APP_KEY)
+    assert detection.watermarked is True
+    assert detection.owner_identity == "u-1"
+    assert detection.text == "midsize"
+    assert detection.length_bits == 768
+
+
+def test_embed_then_detect_fhd_landscape(fhd_landscape):
+    """1920x1080 should use the largest (1024-bit) tier."""
+    result = embed_text(fhd_landscape, "fhd shot", owner="u-1", app_key=APP_KEY)
+    detection = detect_text(result.png_bytes, app_key=APP_KEY)
+    assert detection.watermarked is True
+    assert detection.text == "fhd shot"
+    assert detection.length_bits == 1024
+
+
+def test_embed_then_detect_fhd_portrait():
+    """1080x1920 (portrait phone screenshot) should also use the largest tier."""
+    img = _random_png(1080, 1920)
+    result = embed_text(img, "portrait", owner="u-1", app_key=APP_KEY)
+    detection = detect_text(result.png_bytes, app_key=APP_KEY)
+    assert detection.watermarked is True
+    assert detection.length_bits == 1024
+
+
+def test_detect_with_wrong_key_returns_not_watermarked(big_image):
+    result = embed_text(big_image, "secret", owner="user-1", app_key=APP_KEY)
+    detection = detect_text(result.png_bytes, app_key="totally-different-key")
+    assert detection.watermarked is False
+    assert detection.owner_identity is None
+    assert detection.length_bits is None
+
+
+def test_detect_plain_image_returns_not_watermarked(big_image):
+    detection = detect_text(big_image, app_key=APP_KEY)
+    assert detection.watermarked is False
+
+
+def test_embed_rejects_image_below_smallest_tier():
+    tiny = _random_png(800)
+    with pytest.raises(ValueError, match="too small"):
+        embed_text(tiny, "hello", owner="u-1", app_key=APP_KEY)
+
+
+def test_select_length_bits_picks_largest_tier_that_fits():
+    # tier 1024-bit: short>=1080, long>=1600
+    assert select_length_bits(2000, 2000) == 1024
+    assert select_length_bits(1920, 1080) == 1024
+    assert select_length_bits(1080, 1920) == 1024
+    assert select_length_bits(1600, 1080) == 1024
+    # tier 768-bit: short>=1024, long>=1024
+    assert select_length_bits(1024, 1024) == 768
+    assert select_length_bits(1200, 1200) == 768
+    assert select_length_bits(1500, 1500) == 768
+    # too small for either tier
+    with pytest.raises(ValueError):
+        select_length_bits(1023, 1023)
+    with pytest.raises(ValueError):
+        select_length_bits(1280, 720)  # short side too narrow
+
+
+def test_capacity_report_for_big_image(big_image):
+    report = capacity_report(big_image, owner="alice-7")
+    assert report.image_ok is True
+    assert report.length_bits == 1024
+    # 128 bytes total - 41 envelope - 8 owner = ~79 bytes
+    assert 70 < report.max_text_bytes < 90
+
+
+def test_capacity_report_for_medium_image(medium_image):
+    report = capacity_report(medium_image, owner="alice-7")
+    assert report.image_ok is True
+    assert report.length_bits == 768
+    # 96 bytes total - 49 envelope - 8 owner = ~39 bytes
+    assert 30 < report.max_text_bytes < 50
+
+
+def test_capacity_report_for_fhd_landscape(fhd_landscape):
+    report = capacity_report(fhd_landscape, owner="alice-7")
+    assert report.image_ok is True
+    assert report.length_bits == 1024
+    assert 60 < report.max_text_bytes < 90
+
+
+def test_capacity_report_for_too_small_image():
+    tiny = _random_png(800)
+    report = capacity_report(tiny, owner="alice-7")
+    assert report.image_ok is False
+    assert report.length_bits == 0
+    assert report.max_text_bytes == 0
+
+
+def test_visualize_returns_png(big_image):
+    heatmap_png = visualize(big_image, app_key=APP_KEY)
+    assert heatmap_png[:8] == b"\x89PNG\r\n\x1a\n"

--- a/watermark-service/src/main/java/pl/zzpj/watermark_service/controller/WatermarkController.java
+++ b/watermark-service/src/main/java/pl/zzpj/watermark_service/controller/WatermarkController.java
@@ -36,7 +36,7 @@ public class WatermarkController {
     private static final Logger log = LoggerFactory.getLogger(WatermarkController.class);
 
     private static final ClassificationResult UNKNOWN_CLASSIFICATION =
-            new ClassificationResult("unknown", "unknown", 0.0, List.of());
+            new ClassificationResult("unknown", "unknown", 0.0, 0.0, List.of());
 
     private final SteganographyService steganographyService;
     private final AiServiceFeignClient aiServiceFeignClient;
@@ -97,6 +97,7 @@ public class WatermarkController {
                 .header("X-Image-Category", classification.category())
                 .header("X-Image-Label", classification.label())
                 .header("X-Image-Confidence", String.valueOf(classification.confidence()))
+                .header("X-Image-Category-Confidence", String.valueOf(classification.categoryConfidence()))
                 .body(watermarkedImage);
     }
 

--- a/watermark-service/src/main/java/pl/zzpj/watermark_service/dto/ClassificationResult.java
+++ b/watermark-service/src/main/java/pl/zzpj/watermark_service/dto/ClassificationResult.java
@@ -1,19 +1,24 @@
 package pl.zzpj.watermark_service.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
 /**
  * Client-side DTO mirroring the classification result returned by ai-service.
  *
- * @param label      the most specific ImageNet class label (e.g. "golden retriever")
- * @param category   the broad category mapped from the label (e.g. "dog")
- * @param confidence probability of the top prediction in range [0, 1]
- * @param top3       the three highest-scoring predictions with their labels and confidences
+ * @param label              the most specific ImageNet class label (e.g. "golden retriever")
+ * @param category           the broad category mapped from the label (e.g. "dog")
+ * @param confidence         probability of the top prediction in range [0, 1]
+ * @param categoryConfidence aggregated probability over all labels mapped to the category, in [0, 1]
+ * @param top3               the three highest-scoring predictions with their labels and confidences
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ClassificationResult(
         String label,
         String category,
         double confidence,
+        double categoryConfidence,
         List<TopPrediction> top3
 ) {
     /**

--- a/watermark-service/src/test/java/pl/zzpj/watermark_service/ApplicationTests.java
+++ b/watermark-service/src/test/java/pl/zzpj/watermark_service/ApplicationTests.java
@@ -65,6 +65,7 @@ class ApplicationTests {
                         "test-label",
                         "test-category",
                         0.99,
+                        0.99,
                         List.of(new ClassificationResult.TopPrediction("test-label", 0.99))
                 )
         );


### PR DESCRIPTION
Closes #23.

## Summary
- **AES-256-GCM payload encryption** keyed off `WATERMARK_APP_KEY`, magic bytes `WMPY` + version + 96-bit nonce + 128-bit tag. Without the app key nobody can read or forge a watermark.
- **Reed-Solomon ECC** (16 parity bytes, corrects up to 8 byte errors) wraps the envelope so dwtDctSvd's occasional bit-flips on threshold-sized images don't fail the GCM tag.
- **Spring Cloud Config Server client**: polls `application/default` + `watermark-service/default` at startup, merges into pydantic Settings with env-var precedence, retries with exponential backoff (1s → 16s).
- **Adaptive tiers** with embed-time verification:
  - short ≥ 1080 px AND long ≥ 1600 px → 1024 bit, ~71 bytes of text
  - short ≥ 1024 px AND long ≥ 1024 px → 768 bit, ~39 bytes
- **JWT required on every endpoint** (`/detect` and `/visualize` were public — regression vs Java fixed). Principal sanitized through identifier regex before being embedded.
- **New `POST /api/watermark/capacity`** returning `maxTextBytes` + chosen tier + image dimensions for the calling principal. Powers the GUI's live byte counter.
- **GUI**: capacity probe on image select (with AbortController for stale-response safety), live byte counter, PNG-only file picker on embed tab, subtle PNG-only hints across detect/extract/visualize.
- **Hardening**: Dockerfile runs as non-root user (uid 10001); async ai-service client (no event-loop blocking); EXIF orientation; PNG magic-byte enforcement at API boundary; fail-fast on the public default app key unless `WATERMARK_DEV_MODE=true`; 25 MB / 4 KB size caps on form inputs.

## Test plan
- [ ] `cd watermark-service-py && pytest -q` — 33 tests green
- [ ] `docker compose up -d --build watermark-service`
- [ ] `curl http://localhost:8082/health` → `{"status":"UP"}`
- [ ] Logs show `Loaded 7 properties from config-server` + `Registered with Eureka as WATERMARK-SERVICE`
- [ ] Login to GUI (http://localhost:5173, admin@gmail.com / admin)
- [ ] Embed tab: upload a 1920×1080 PNG, confirm capacity panel shows "📐 1920×1080 px — możesz ukryć maksymalnie 71 bajtów"
- [ ] Submit with text → download watermarked PNG
- [ ] Detect tab: confirm `ownerIdentity: "admin-1"`, `lengthBits: 1024`
- [ ] Extract tab: confirm original text returned
- [ ] Try uploading a JPG on embed → server returns 400 with PNG-only message
- [ ] Try a 800×800 image → capacity panel shows "Obraz jest za mały"
- [ ] Try `unset WATERMARK_DEV_MODE` and boot watermark-service → service refuses to start (fail-fast on dev default key)

## Notes for review
- Crypto wire format documented in `watermark-service-py/app/crypto.py` module docstring.
- README has a "User contract: PNG in, PNG out, do not recompress" section explaining why JPG re-encode destroys the watermark — this is a fundamental DWT-DCT-SVD limit, not a regression.
- Config repo file `watermark-service.yml` already had `watermark.app-key: ${WATERMARK_APP_KEY:local-dev-watermark-secret}` — Python now reads it.
- `Co-Authored-By` and AI attribution intentionally omitted per project convention.

🤖 PR ready for ultrareview if useful.