### PR TITLE
fix: add ulimits to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,10 @@ services:
       - sonarqube_extensions:/opt/sonarqube/extensions
       - sonarqube_logs:/opt/sonarqube/logs
     restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
 
   sonar-scan:
     image: gradle:8.14.4-jdk21


### PR DESCRIPTION
## Problem
`SonarQube` failed to start correctly because `Elasticsearch` required higher system limits (`ulimits`) than those provided by the default container configuration. As a result, `Elasticsearch` could not initialize successfully, preventing the entire `SonarQube` service from becoming available.

## Fix
Added the required `ulimits` configuration to `docker-compose.yml` to meet `Elasticsearch` and `SonarQube` runtime requirements. With the increased limits in place, `Elasticsearch` starts successfully and `SonarQube` completes its initialization process.

## Verification
- Started the environment using `docker-compose up` and confirmed all containers reached a healthy state.
- Verified that `Elasticsearch` logs no longer contain errors related to insufficient system limits.
- Confirmed that `SonarQube` completes startup successfully and is accessible through the web interface.
- Verified that project analysis can be executed successfully.