### PR TITLE
Feature/31 user registration

### DIFF
--- a/auth-server/src/main/java/pl/zzpj/auth_server/controller/AuthController.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/controller/AuthController.java
@@ -8,8 +8,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 import pl.zzpj.auth_server.dto.LoginRequest;
 import pl.zzpj.auth_server.dto.LoginResponse;
+import pl.zzpj.auth_server.dto.RegisterRequest;
+import pl.zzpj.auth_server.dto.RegisterResponse;
 import pl.zzpj.auth_server.repository.UserRepository;
 import pl.zzpj.auth_server.service.JwtService;
+import pl.zzpj.auth_server.service.RegistrationService;
 
 @RestController
 @RequestMapping("/auth")
@@ -19,6 +22,13 @@ public class AuthController {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final RegistrationService registrationService;
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        RegisterResponse response = registrationService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {

--- a/auth-server/src/main/java/pl/zzpj/auth_server/dto/RegisterRequest.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/dto/RegisterRequest.java
@@ -1,0 +1,32 @@
+package pl.zzpj.auth_server.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import pl.zzpj.auth_server.exception.UnknownRegistrationPropertyException;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRequest {
+
+    @NotBlank(message = "Username cannot be empty")
+    @Size(min = 3, max = 50)
+    private String username;
+
+    @Email(message = "Email should be valid")
+    @NotBlank(message = "Email cannot be empty")
+    private String email;
+
+    @NotBlank(message = "Password cannot be empty")
+    private String password;
+
+    @JsonAnySetter
+    public void rejectUnknownProperty(String name, Object value) {
+        throw new UnknownRegistrationPropertyException(name);
+    }
+}

--- a/auth-server/src/main/java/pl/zzpj/auth_server/dto/RegisterResponse.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/dto/RegisterResponse.java
@@ -1,0 +1,14 @@
+package pl.zzpj.auth_server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import pl.zzpj.auth_server.entity.UserRole;
+
+@Data
+@AllArgsConstructor
+public class RegisterResponse {
+    private Long id;
+    private String username;
+    private String email;
+    private UserRole role;
+}

--- a/auth-server/src/main/java/pl/zzpj/auth_server/exception/DuplicateUserFieldException.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/exception/DuplicateUserFieldException.java
@@ -1,0 +1,15 @@
+package pl.zzpj.auth_server.exception;
+
+public class DuplicateUserFieldException extends RuntimeException {
+
+    private final String field;
+
+    public DuplicateUserFieldException(String field, String message) {
+        super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/auth-server/src/main/java/pl/zzpj/auth_server/exception/GlobalExceptionHandler.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/exception/GlobalExceptionHandler.java
@@ -31,6 +31,18 @@ public class GlobalExceptionHandler {
                 .body("Invalid JSON format or unknown properties in request.");
     }
 
+    @ExceptionHandler(UnknownRegistrationPropertyException.class)
+    public ResponseEntity<String> handleUnknownRegistrationProperty(UnknownRegistrationPropertyException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(DuplicateUserFieldException.class)
+    public ResponseEntity<Map<String, String>> handleDuplicateUserField(DuplicateUserFieldException ex) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put(ex.getField(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errors);
+    }
+
     @ExceptionHandler({BadCredentialsException.class, EmailNotFoundException.class})
     public ResponseEntity<String> handleAuthenticationErrors(Exception ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/auth-server/src/main/java/pl/zzpj/auth_server/exception/UnknownRegistrationPropertyException.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/exception/UnknownRegistrationPropertyException.java
@@ -1,0 +1,8 @@
+package pl.zzpj.auth_server.exception;
+
+public class UnknownRegistrationPropertyException extends RuntimeException {
+
+    public UnknownRegistrationPropertyException(String property) {
+        super("Unknown registration property: " + property);
+    }
+}

--- a/auth-server/src/main/java/pl/zzpj/auth_server/repository/UserRepository.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/repository/UserRepository.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
 }

--- a/auth-server/src/main/java/pl/zzpj/auth_server/security/SecurityConfig.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/security/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/auth/validate").permitAll()
+                        .requestMatchers("/auth/login", "/auth/register", "/auth/validate").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/auth-server/src/main/java/pl/zzpj/auth_server/service/RegistrationService.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/service/RegistrationService.java
@@ -1,0 +1,50 @@
+package pl.zzpj.auth_server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pl.zzpj.auth_server.dto.RegisterRequest;
+import pl.zzpj.auth_server.dto.RegisterResponse;
+import pl.zzpj.auth_server.entity.User;
+import pl.zzpj.auth_server.entity.UserRole;
+import pl.zzpj.auth_server.exception.DuplicateUserFieldException;
+import pl.zzpj.auth_server.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RegistrationService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Transactional
+    public RegisterResponse register(RegisterRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateUserFieldException("email", "Email is already registered.");
+        }
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new DuplicateUserFieldException("username", "Username is already taken.");
+        }
+
+        User user = User.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(UserRole.USER)
+                .build();
+
+        try {
+            User savedUser = userRepository.saveAndFlush(user);
+            return new RegisterResponse(
+                    savedUser.getId(),
+                    savedUser.getUsername(),
+                    savedUser.getEmail(),
+                    savedUser.getRole()
+            );
+        } catch (DataIntegrityViolationException exception) {
+            throw new DuplicateUserFieldException("user", "Username or email is already registered.");
+        }
+    }
+}

--- a/gui/src/routes/+page.svelte
+++ b/gui/src/routes/+page.svelte
@@ -101,14 +101,9 @@
         accountLoading = true;
         accountError = '';
         try {
-            const [plansResponse, subscriptionResponse, tokensResponse] = await Promise.all([
-                apiGet('/api/subscriptions/plans'),
-                apiGet('/api/subscriptions/me'),
-                apiGet('/api/subscriptions/me/tokens')
-            ]);
-            plans = plansResponse;
-            subscription = subscriptionResponse;
-            tokenBalance = tokensResponse;
+            plans = await apiGet('/api/subscriptions/plans');
+            subscription = await apiGet('/api/subscriptions/me');
+            tokenBalance = await apiGet('/api/subscriptions/me/tokens');
         } catch (error) {
             accountError = error instanceof Error ? error.message : 'Nie udało się pobrać danych subskrypcji.';
         } finally {

--- a/gui/src/routes/login/+page.svelte
+++ b/gui/src/routes/login/+page.svelte
@@ -1,7 +1,12 @@
 <script>
+    import { onMount } from 'svelte';
+
+    const registeredLoginKey = 'stegocloud_registered_login';
+
     let email = $state('admin@gmail.com');
     let password = $state('admin');
     let errorMessage = $state('');
+    let infoMessage = $state('');
     let isLoggingIn = $state(false);
 
     const demoUsers = [
@@ -11,6 +16,21 @@
         ['pro@gmail.com', 'pro'],
         ['lowbalance@gmail.com', 'lowbalance']
     ];
+
+    onMount(() => {
+        const registeredLogin = sessionStorage.getItem(registeredLoginKey);
+        if (!registeredLogin) return;
+
+        sessionStorage.removeItem(registeredLoginKey);
+        try {
+            const credentials = JSON.parse(registeredLogin);
+            email = credentials.email || email;
+            password = credentials.password || '';
+            infoMessage = 'Account created. You can log in now.';
+        } catch {
+            infoMessage = 'Account created. You can log in now.';
+        }
+    });
 
     async function handleLogin(event) {
         event.preventDefault();
@@ -42,6 +62,7 @@
     function useDemo(demoEmail, demoPassword) {
         email = demoEmail;
         password = demoPassword;
+        infoMessage = '';
     }
 </script>
 
@@ -68,17 +89,29 @@
             </button>
         </form>
 
+        <a class="register-link" href="/register">Create regular account</a>
+
+        {#if infoMessage}
+            <div class="success">{infoMessage}</div>
+        {/if}
+
         {#if errorMessage}
             <div class="error">{errorMessage}</div>
         {/if}
 
-        <div class="demo-list">
-            {#each demoUsers as [demoEmail, demoPassword]}
-                <button type="button" onclick={() => useDemo(demoEmail, demoPassword)}>
-                    {demoEmail.replace('@gmail.com', '')}
-                </button>
-            {/each}
-        </div>
+        <section class="demo-section" aria-label="Demo accounts">
+            <div class="demo-divider">
+                <span>Demo accounts</span>
+            </div>
+
+            <div class="demo-list">
+                {#each demoUsers as [demoEmail, demoPassword]}
+                    <button type="button" onclick={() => useDemo(demoEmail, demoPassword)}>
+                        {demoEmail.replace('@gmail.com', '')}
+                    </button>
+                {/each}
+            </div>
+        </section>
     </section>
 </main>
 
@@ -161,25 +194,69 @@
         color: #fff;
     }
 
+    .register-link {
+        display: block;
+        margin-top: 10px;
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 11px 14px;
+        color: #344054;
+        background: #fff;
+        font-weight: 800;
+        text-align: center;
+        text-decoration: none;
+    }
+
     button:disabled {
         background: #98a2b3;
         cursor: not-allowed;
     }
 
-    .error {
+    .error, .success {
         margin-top: 16px;
         padding: 11px 13px;
         border-radius: 8px;
+    }
+
+    .error {
         background: #fff1f2;
         border: 1px solid #fecdd3;
         color: #be123c;
+    }
+
+    .success {
+        background: #ecfdf3;
+        border: 1px solid #bbf7d0;
+        color: #15803d;
+    }
+
+    .demo-section {
+        margin-top: 20px;
+    }
+
+    .demo-divider {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 10px;
+        align-items: center;
+        color: #667085;
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+    }
+
+    .demo-divider::before,
+    .demo-divider::after {
+        content: "";
+        height: 1px;
+        background: #d9e2ec;
     }
 
     .demo-list {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         gap: 8px;
-        margin-top: 20px;
+        margin-top: 14px;
     }
 
     .demo-list button {

--- a/gui/src/routes/register/+page.svelte
+++ b/gui/src/routes/register/+page.svelte
@@ -1,0 +1,190 @@
+<script>
+    const registeredLoginKey = 'stegocloud_registered_login';
+
+    let username = $state('');
+    let email = $state('');
+    let password = $state('');
+    let errorMessage = $state('');
+    let isRegistering = $state(false);
+
+    async function handleRegister(event) {
+        event.preventDefault();
+        errorMessage = '';
+        isRegistering = true;
+
+        try {
+            const response = await fetch('/auth/register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, email, password })
+            });
+
+            if (response.ok) {
+                sessionStorage.setItem(registeredLoginKey, JSON.stringify({ email, password }));
+                window.location.href = '/login';
+            } else {
+                errorMessage = await readError(response);
+            }
+        } catch {
+            errorMessage = 'Could not connect to auth-server.';
+        } finally {
+            isRegistering = false;
+        }
+    }
+
+    async function readError(response) {
+        try {
+            const data = await response.json();
+            if (typeof data === 'string') return data;
+            if (data.email) return data.email;
+            if (data.username) return data.username;
+            if (data.password) return data.password;
+            if (data.user) return data.user;
+            if (data.error) return data.error;
+        } catch {
+            const text = await response.text();
+            if (text) return text;
+        }
+        return 'Registration failed.';
+    }
+</script>
+
+<main class="container">
+    <section class="register-card">
+        <header>
+            <h1>Create Account</h1>
+            <p>New accounts start as regular users on the FREE plan.</p>
+        </header>
+
+        <form onsubmit={handleRegister}>
+            <label>
+                <span>Username</span>
+                <input type="text" bind:value={username} required minlength="3" maxlength="50" placeholder="username" />
+            </label>
+
+            <label>
+                <span>Email</span>
+                <input type="email" bind:value={email} required placeholder="user@example.com" />
+            </label>
+
+            <label>
+                <span>Password</span>
+                <input type="password" bind:value={password} required placeholder="Password" />
+            </label>
+
+            <button type="submit" disabled={isRegistering}>
+                {isRegistering ? 'Creating...' : 'Create account'}
+            </button>
+        </form>
+
+        {#if errorMessage}
+            <div class="error">{errorMessage}</div>
+        {/if}
+
+        <a class="login-link" href="/login">Back to login</a>
+    </section>
+</main>
+
+<style>
+    :global(body) {
+        margin: 0;
+        background: #f3f5f7;
+        color: #1f2933;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .container {
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 20px;
+    }
+
+    .register-card {
+        width: min(100%, 430px);
+        background: #fff;
+        border: 1px solid #d9e2ec;
+        border-radius: 8px;
+        padding: 32px;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    }
+
+    header {
+        margin-bottom: 24px;
+        text-align: center;
+    }
+
+    h1 {
+        margin: 0;
+        font-size: 1.7rem;
+        color: #172033;
+    }
+
+    p {
+        margin: 8px 0 0;
+        color: #667085;
+    }
+
+    form {
+        display: grid;
+        gap: 16px;
+    }
+
+    label {
+        display: grid;
+        gap: 7px;
+        font-weight: 700;
+    }
+
+    input {
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 12px 14px;
+        font-size: 1rem;
+        background: #f8fafc;
+    }
+
+    input:focus {
+        outline: none;
+        border-color: #2563eb;
+        background: #fff;
+    }
+
+    button {
+        margin-top: 6px;
+        border: 0;
+        border-radius: 8px;
+        padding: 11px 14px;
+        background: #2563eb;
+        color: #fff;
+        font-weight: 800;
+        cursor: pointer;
+    }
+
+    button:disabled {
+        background: #98a2b3;
+        cursor: not-allowed;
+    }
+
+    .error {
+        margin-top: 16px;
+        padding: 11px 13px;
+        border-radius: 8px;
+        background: #fff1f2;
+        border: 1px solid #fecdd3;
+        color: #be123c;
+    }
+
+    .login-link {
+        display: block;
+        margin-top: 20px;
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 11px 14px;
+        color: #344054;
+        background: #fff;
+        font-weight: 800;
+        text-align: center;
+        text-decoration: none;
+    }
+</style>

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/SubscriptionStore.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/SubscriptionStore.java
@@ -47,12 +47,17 @@ public class SubscriptionStore {
     }
 
     private UserSubscriptionState create(UserSubscriptionState initialState) {
-        ActiveSubscriptionEntity subscription = subscriptionRepository.save(
-                ActiveSubscriptionEntity.from(initialState.subscription())
+        subscriptionRepository.insertIfMissing(
+                initialState.subscription().userId(),
+                initialState.subscription().planCode().name(),
+                initialState.subscription().activeFrom()
         );
-        TokenBalanceEntity tokenBalance = tokenBalanceRepository.save(
-                TokenBalanceEntity.from(initialState.tokenBalance())
+        tokenBalanceRepository.insertIfMissing(
+                initialState.tokenBalance().userId(),
+                initialState.tokenBalance().availableTokens(),
+                initialState.tokenBalance().reservedTokens()
         );
-        return new UserSubscriptionState(subscription.toDomain(), tokenBalance.toDomain());
+        return find(initialState.subscription().userId())
+                .orElseThrow(() -> new IllegalStateException("Subscription state could not be created"));
     }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/ActiveSubscriptionRepository.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/ActiveSubscriptionRepository.java
@@ -1,7 +1,24 @@
 package pl.zzpj.subscription_service.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import pl.zzpj.subscription_service.persistence.entity.ActiveSubscriptionEntity;
 
+import java.time.Instant;
+
 public interface ActiveSubscriptionRepository extends JpaRepository<ActiveSubscriptionEntity, String> {
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO subscription_schema.active_subscriptions (user_id, plan_code, active_from, active_until)
+            VALUES (:userId, :planCode, :activeFrom, NULL)
+            ON CONFLICT (user_id) DO NOTHING
+            """, nativeQuery = true)
+    void insertIfMissing(
+            @Param("userId") String userId,
+            @Param("planCode") String planCode,
+            @Param("activeFrom") Instant activeFrom
+    );
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/TokenBalanceRepository.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/TokenBalanceRepository.java
@@ -1,7 +1,22 @@
 package pl.zzpj.subscription_service.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import pl.zzpj.subscription_service.persistence.entity.TokenBalanceEntity;
 
 public interface TokenBalanceRepository extends JpaRepository<TokenBalanceEntity, String> {
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO subscription_schema.token_balances (user_id, available_tokens, reserved_tokens)
+            VALUES (:userId, :availableTokens, :reservedTokens)
+            ON CONFLICT (user_id) DO NOTHING
+            """, nativeQuery = true)
+    void insertIfMissing(
+            @Param("userId") String userId,
+            @Param("availableTokens") int availableTokens,
+            @Param("reservedTokens") int reservedTokens
+    );
 }


### PR DESCRIPTION
## Summary

- Added public `POST /auth/register` endpoint in `auth-server`.
- Registration creates only `USER` accounts and rejects extra request fields such as `role`.
- Added duplicate email/username handling with client-friendly errors.
- Passwords are hashed with the existing BCrypt encoder and never returned by the API.
- Added minimal GUI registration flow while preserving quick demo login buttons.
- After successful registration, the user is redirected to login with credentials prefilled.
- Made lazy FREE subscription creation idempotent in `subscription-service` to avoid first-login duplicate key errors.
- Separated demo login accounts visually with a subtle `Demo accounts` divider.

Closes #31 