### PR TITLE
docs: add OpenAPI documentation to all service endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,18 @@ docker compose down -v
 | Auth Server | http://localhost:8081 |
 | Subscription Service | http://localhost:8085 |
 | Watermark Service Python/FastAPI | http://localhost:8082 |
-| Watermark Service Swagger | http://localhost:8082/docs |
 | AI Service | http://localhost:8084 |
 | SonarQube | http://localhost:9000 |
 | PostgreSQL host port | `localhost:5433` |
+
+## Dokumentacja API (OpenAPI)
+
+| Usluga | URL |
+|---|---|
+| Auth Server | http://localhost:8081/swagger-ui/index.html |
+| Subscription Service | http://localhost:8085/swagger-ui/index.html |
+| AI Service | http://localhost:8084/swagger-ui/index.html |
+| Watermark Service | http://localhost:8082/docs |
 
 ## Przydatne endpointy
 

--- a/ai-service/build.gradle.kts
+++ b/ai-service/build.gradle.kts
@@ -24,6 +24,7 @@ extra["springCloudVersion"] = "2025.0.1"
 dependencies {
         implementation("org.springframework.boot:spring-boot-starter-web")
         implementation("org.springframework.boot:spring-boot-starter-security")
+        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
         implementation("org.springframework.cloud:spring-cloud-starter-config")
         implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
         implementation("org.springframework.cloud:spring-cloud-starter-openfeign")

--- a/ai-service/src/main/java/pl/zzpj/ai_service/ClassificationController.java
+++ b/ai-service/src/main/java/pl/zzpj/ai_service/ClassificationController.java
@@ -1,6 +1,9 @@
 package pl.zzpj.ai_service;
 
 import ai.onnxruntime.OrtException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -11,23 +14,38 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 @Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Tag(name = "Classification", description = "AI Image Classification API")
 public class ClassificationController {
 
     private final ClassificationService classificationService;
 
-    @PostMapping(value = "/classify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(
+        value = "/classify",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    @Operation(
+        summary = "Classify image",
+        description = "Uses an ONNX model to classify the content of the provided image file."
+    )
     public ResponseEntity<ClassificationResult> classify(
-            @RequestPart("file") MultipartFile file) throws IOException, OrtException {
-
-        log.info("Classifying image: {}, size: {} bytes", file.getOriginalFilename(), file.getSize());
+        @RequestPart("file") MultipartFile file
+    ) throws IOException, OrtException {
+        log.info(
+            "Classifying image: {}, size: {} bytes",
+            file.getOriginalFilename(),
+            file.getSize()
+        );
         ClassificationResult result = classificationService.classify(file);
-        log.info("Result: category={}, label={}, confidence={}", result.category(), result.label(), result.confidence());
+        log.info(
+            "Result: category={}, label={}, confidence={}",
+            result.category(),
+            result.label(),
+            result.confidence()
+        );
         return ResponseEntity.ok(result);
     }
 }

--- a/auth-server/build.gradle.kts
+++ b/auth-server/build.gradle.kts
@@ -24,6 +24,7 @@ extra["springCloudVersion"] = "2025.0.1"
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
 	implementation("org.springframework.cloud:spring-cloud-starter-config")
 	implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/auth-server/src/main/java/pl/zzpj/auth_server/controller/AuthController.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/controller/AuthController.java
@@ -1,11 +1,17 @@
 package pl.zzpj.auth_server.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import pl.zzpj.auth_server.dto.LoginRequest;
 import pl.zzpj.auth_server.dto.LoginResponse;
 import pl.zzpj.auth_server.dto.RegisterRequest;
@@ -17,6 +23,10 @@ import pl.zzpj.auth_server.service.RegistrationService;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(
+    name = "Authentication",
+    description = "Authentication and registration API"
+)
 public class AuthController {
 
     private final UserRepository userRepository;
@@ -25,25 +35,55 @@ public class AuthController {
     private final RegistrationService registrationService;
 
     @PostMapping("/register")
-    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+    @Operation(
+        summary = "Register user",
+        description = "Creates a new user account with the provided details."
+    )
+    public ResponseEntity<RegisterResponse> register(
+        @Valid @RequestBody RegisterRequest request
+    ) {
         RegisterResponse response = registrationService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/login")
+    @Operation(
+        summary = "Login user",
+        description = "Authenticates a user and returns a JWT token."
+    )
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
-        return userRepository.findByEmail(request.getEmail())
-                .map(user -> {
-                    if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-                        String token = jwtService.generateToken(user.getUsername(), user.getId(), user.getRole());
-                        return ResponseEntity.ok(new LoginResponse(token));
-                    }
-                    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid password");
-                })
-                .orElse(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not found"));
+        return userRepository
+            .findByEmail(request.getEmail())
+            .map(user -> {
+                if (
+                    passwordEncoder.matches(
+                        request.getPassword(),
+                        user.getPassword()
+                    )
+                ) {
+                    String token = jwtService.generateToken(
+                        user.getUsername(),
+                        user.getId(),
+                        user.getRole()
+                    );
+                    return ResponseEntity.ok(new LoginResponse(token));
+                }
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    "Invalid password"
+                );
+            })
+            .orElse(
+                ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    "User not found"
+                )
+            );
     }
 
     @PostMapping("/validate")
+    @Operation(
+        summary = "Validate token",
+        description = "Validates the provided JWT token."
+    )
     public ResponseEntity<Boolean> validateToken(@RequestParam String token) {
         try {
             jwtService.validateToken(token);

--- a/auth-server/src/main/java/pl/zzpj/auth_server/security/SecurityConfig.java
+++ b/auth-server/src/main/java/pl/zzpj/auth_server/security/SecurityConfig.java
@@ -11,14 +11,28 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)
+        throws Exception {
         http.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/auth/register", "/auth/validate").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+            .authorizeHttpRequests(auth ->
+                auth
+                    .requestMatchers(
+                        "/auth/login",
+                        "/auth/register",
+                        "/auth/validate",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html"
+                    )
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+            )
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            );
         return http.build();
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,15 @@ services:
     ports:
       - "8888:8888"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "-u", "${CONFIG_SERVER_USER}:${CONFIG_SERVER_PASSWORD}", "http://localhost:8888/auth-server/default" ]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "-u",
+          "${CONFIG_SERVER_USER}:${CONFIG_SERVER_PASSWORD}",
+          "http://localhost:8888/auth-server/default",
+        ]
       interval: 5s
       timeout: 5s
       retries: 20
@@ -90,6 +98,8 @@ services:
       EUREKA_URL: http://${EUREKA_USER}:${EUREKA_PASSWORD}@eureka-server:8761/eureka/
       EUREKA_USER: ${EUREKA_USER}
       EUREKA_PASSWORD: ${EUREKA_PASSWORD}
+    ports:
+      - "8084:8084"
     depends_on:
       config-server:
         condition: service_healthy

--- a/subscription-service/build.gradle.kts
+++ b/subscription-service/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
 	implementation("org.springframework.cloud:spring-cloud-starter-config")
 	implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
 	implementation("org.springframework.cloud:spring-cloud-starter-openfeign")

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/SubscriptionQueryController.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/SubscriptionQueryController.java
@@ -1,5 +1,9 @@
 package pl.zzpj.subscription_service.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,32 +15,43 @@ import pl.zzpj.subscription_service.controller.dto.PlanView;
 import pl.zzpj.subscription_service.controller.dto.TokenBalanceView;
 import pl.zzpj.subscription_service.domain.subscription.SubscriptionPlan;
 
-import java.security.Principal;
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/subscriptions")
+@Tag(
+    name = "Subscription Query",
+    description = "API for querying user subscriptions and plans"
+)
 public class SubscriptionQueryController {
 
     private final SubscriptionQueryService subscriptionQueryService;
     private final UserIdentityResolver userIdentityResolver;
 
     public SubscriptionQueryController(
-            SubscriptionQueryService subscriptionQueryService,
-            UserIdentityResolver userIdentityResolver
+        SubscriptionQueryService subscriptionQueryService,
+        UserIdentityResolver userIdentityResolver
     ) {
         this.subscriptionQueryService = subscriptionQueryService;
         this.userIdentityResolver = userIdentityResolver;
     }
 
     @GetMapping("/plans")
+    @Operation(
+        summary = "List available plans",
+        description = "Returns a list of all available subscription plans."
+    )
     public List<PlanView> plans() {
-        return subscriptionQueryService.availablePlans().stream()
-                .map(this::toPlanView)
-                .toList();
+        return subscriptionQueryService
+            .availablePlans()
+            .stream()
+            .map(this::toPlanView)
+            .toList();
     }
 
     @GetMapping("/me")
+    @Operation(
+        summary = "Current subscription",
+        description = "Returns details of the current user's active subscription."
+    )
     public CurrentSubscriptionView currentSubscription(Principal principal) {
         String userId = userIdentityResolver.resolve(principal);
         UserSubscriptionState state = subscriptionQueryService.stateFor(userId);
@@ -44,6 +59,10 @@ public class SubscriptionQueryController {
     }
 
     @GetMapping("/me/tokens")
+    @Operation(
+        summary = "Token balance",
+        description = "Returns the remaining token balance for the current user."
+    )
     public TokenBalanceView tokenBalance(Principal principal) {
         String userId = userIdentityResolver.resolve(principal);
         UserSubscriptionState state = subscriptionQueryService.stateFor(userId);
@@ -51,6 +70,10 @@ public class SubscriptionQueryController {
     }
 
     private PlanView toPlanView(SubscriptionPlan plan) {
-        return new PlanView(plan.code(), plan.monthlyTokens(), plan.allowedOperations());
+        return new PlanView(
+            plan.code(),
+            plan.monthlyTokens(),
+            plan.allowedOperations()
+        );
     }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/SubscriptionStatusController.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/SubscriptionStatusController.java
@@ -1,5 +1,7 @@
 package pl.zzpj.subscription_service.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -7,9 +9,17 @@ import pl.zzpj.subscription_service.controller.dto.ServiceStatus;
 
 @RestController
 @RequestMapping("/api/subscriptions")
+@Tag(
+    name = "Subscription Status",
+    description = "Service health and status API"
+)
 public class SubscriptionStatusController {
 
     @GetMapping("/status")
+    @Operation(
+        summary = "Service status",
+        description = "Returns the current status of the subscription service."
+    )
     public ServiceStatus status() {
         return new ServiceStatus("subscription-service", "UP");
     }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/TokenReservationController.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/TokenReservationController.java
@@ -1,5 +1,9 @@
 package pl.zzpj.subscription_service.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,61 +24,105 @@ import pl.zzpj.subscription_service.domain.token.decision.RejectedPlanNotFound;
 import pl.zzpj.subscription_service.domain.token.decision.TokenDecision;
 import pl.zzpj.subscription_service.persistence.entity.TokenReservationEntity;
 
-import java.security.Principal;
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/api/tokens/reservations")
+@Tag(
+    name = "Token Reservation",
+    description = "API for managing token reservations for operations"
+)
 public class TokenReservationController {
 
     private final TokenReservationCommandService reservationCommandService;
     private final UserIdentityResolver userIdentityResolver;
 
     public TokenReservationController(
-            TokenReservationCommandService reservationCommandService,
-            UserIdentityResolver userIdentityResolver
+        TokenReservationCommandService reservationCommandService,
+        UserIdentityResolver userIdentityResolver
     ) {
         this.reservationCommandService = reservationCommandService;
         this.userIdentityResolver = userIdentityResolver;
     }
 
     @PostMapping
+    @Operation(
+        summary = "Reserve tokens",
+        description = "Creates a new token reservation for a specific operation."
+    )
     public ResponseEntity<?> reserve(
-            Principal principal,
-            @RequestBody CreateTokenReservationRequest request
+        Principal principal,
+        @RequestBody CreateTokenReservationRequest request
     ) {
         String userId = userIdentityResolver.resolve(principal);
         TokenDecision decision = reservationCommandService.reserve(
-                userId,
-                new CreateTokenReservationCommand(request.operation(), request.externalOperationId())
+            userId,
+            new CreateTokenReservationCommand(
+                request.operation(),
+                request.externalOperationId()
+            )
         );
         return toResponse(decision);
     }
 
     @PostMapping("/{reservationId}/consume")
-    public TokenReservationResponse consume(Principal principal, @PathVariable UUID reservationId) {
+    @Operation(
+        summary = "Consume reservation",
+        description = "Finalizes a token reservation, deducting tokens from the balance."
+    )
+    public TokenReservationResponse consume(
+        Principal principal,
+        @PathVariable UUID reservationId
+    ) {
         String userId = userIdentityResolver.resolve(principal);
-        TokenReservationEntity reservation = reservationCommandService.consume(userId, reservationId);
+        TokenReservationEntity reservation = reservationCommandService.consume(
+            userId,
+            reservationId
+        );
         return TokenReservationResponse.from(reservation);
     }
 
     @PostMapping("/{reservationId}/release")
-    public TokenReservationResponse release(Principal principal, @PathVariable UUID reservationId) {
+    @Operation(
+        summary = "Release reservation",
+        description = "Cancels a token reservation, returning tokens to the balance."
+    )
+    public TokenReservationResponse release(
+        Principal principal,
+        @PathVariable UUID reservationId
+    ) {
         String userId = userIdentityResolver.resolve(principal);
-        TokenReservationEntity reservation = reservationCommandService.release(userId, reservationId);
+        TokenReservationEntity reservation = reservationCommandService.release(
+            userId,
+            reservationId
+        );
         return TokenReservationResponse.from(reservation);
     }
 
     private ResponseEntity<?> toResponse(TokenDecision decision) {
         return switch (decision) {
-            case Accepted accepted -> ResponseEntity.status(HttpStatus.CREATED)
-                    .body(TokenReservationResponse.from(accepted.reservation()));
-            case RejectedInsufficientTokens rejected -> ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(TokenReservationErrorResponse.from("INSUFFICIENT_TOKENS", rejected));
-            case RejectedOperationNotAllowed rejected -> ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(TokenReservationErrorResponse.from("OPERATION_NOT_ALLOWED", rejected));
-            case RejectedPlanNotFound rejected -> ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(TokenReservationErrorResponse.from("PLAN_NOT_FOUND", rejected));
+            case Accepted accepted -> ResponseEntity.status(
+                HttpStatus.CREATED
+            ).body(TokenReservationResponse.from(accepted.reservation()));
+            case RejectedInsufficientTokens rejected -> ResponseEntity.status(
+                HttpStatus.CONFLICT
+            ).body(
+                TokenReservationErrorResponse.from(
+                    "INSUFFICIENT_TOKENS",
+                    rejected
+                )
+            );
+            case RejectedOperationNotAllowed rejected -> ResponseEntity.status(
+                HttpStatus.FORBIDDEN
+            ).body(
+                TokenReservationErrorResponse.from(
+                    "OPERATION_NOT_ALLOWED",
+                    rejected
+                )
+            );
+            case RejectedPlanNotFound rejected -> ResponseEntity.status(
+                HttpStatus.CONFLICT
+            ).body(
+                TokenReservationErrorResponse.from("PLAN_NOT_FOUND", rejected)
+            );
         };
     }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/security/SecurityConfig.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/security/SecurityConfig.java
@@ -19,19 +19,31 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)
+        throws Exception {
         http.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/actuator/health",
-                                "/actuator/health/**",
-                                "/api/subscriptions/status",
-                                "/error"
-                        ).permitAll()
-                        .anyRequest().authenticated()
-                )
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+            .authorizeHttpRequests(auth ->
+                auth
+                    .requestMatchers(
+                        "/actuator/health",
+                        "/actuator/health/**",
+                        "/api/subscriptions/status",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/error"
+                    )
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+            )
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .addFilterBefore(
+                jwtFilter,
+                UsernamePasswordAuthenticationFilter.class
+            );
 
         return http.build();
     }

--- a/watermark-service-py/app/routes.py
+++ b/watermark-service-py/app/routes.py
@@ -6,7 +6,15 @@ import json
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import Response
 
 from app.ai_client import ClassificationResult, classify_or_fallback
@@ -78,7 +86,9 @@ def _read_png(image_bytes: bytes) -> None:
     """Reject non-PNG uploads on the embed path so the GUI's PNG-only contract
     is enforced at the server boundary, not just by the file-picker filter."""
     if len(image_bytes) > _MAX_IMAGE_BYTES:
-        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+        raise HTTPException(
+            413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)"
+        )
     if not image_bytes.startswith(_PNG_MAGIC):
         raise HTTPException(
             400,
@@ -116,24 +126,38 @@ async def _classify_when_entitled(
             bearer_token=bearer_token,
         )
     except Exception:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise
 
-    await consume_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+    await consume_reservation(
+        settings,
+        reservation_id=reservation.reservation_id,
+        bearer_token=bearer_token,
+    )
     return classification
 
 
-@router.post("/embed")
+@router.post(
+    "/embed",
+    summary="Embed watermark",
+    description="Embeds a text watermark into a PNG image using the owner's identity.",
+)
 async def embed(
     request: Request,
-    image: Annotated[UploadFile, File()],
-    text: Annotated[str, Form()],
+    image: Annotated[UploadFile, File(...)],
+    text: Annotated[str, Form(...)],
     principal: Annotated[str, Depends(require_principal)],
 ):
     if not text or not text.strip():
         raise HTTPException(400, detail="text must not be blank")
     if len(text.encode("utf-8")) > _MAX_TEXT_BYTES:
-        raise HTTPException(413, detail=f"Text too large (max {_MAX_TEXT_BYTES} bytes)")
+        raise HTTPException(
+            413, detail=f"Text too large (max {_MAX_TEXT_BYTES} bytes)"
+        )
 
     settings = _settings(request)
     image_bytes = await image.read()
@@ -177,19 +201,37 @@ async def embed(
             app_key=settings.watermark_app_key,
         )
     except ValueError as exc:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise HTTPException(400, detail=str(exc))
     except RuntimeError as exc:
         # embed verification failed at every tier — image content is
         # pathological for the watermark; user can try a larger image.
-        logger.warning("Embed verification failed for principal=%s: %s", principal, exc)
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        logger.warning(
+            "Embed verification failed for principal=%s: %s", principal, exc
+        )
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise HTTPException(422, detail=str(exc))
     except Exception:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise
 
-    await consume_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+    await consume_reservation(
+        settings,
+        reservation_id=reservation.reservation_id,
+        bearer_token=bearer_token,
+    )
 
     return Response(
         content=result.png_bytes,
@@ -198,31 +240,51 @@ async def embed(
             "X-Image-Category": classification.category,
             "X-Image-Label": classification.label,
             "X-Image-Confidence": str(classification.confidence),
-            "X-Image-Category-Confidence": str(classification.category_confidence),
+            "X-Image-Category-Confidence": str(
+                classification.category_confidence
+            ),
             "X-Max-Text-Bytes": str(report.max_text_bytes),
             "X-Watermark-Length-Bits": str(report.length_bits),
         },
     )
 
 
-@router.post("/detect")
+@router.post(
+    "/detect",
+    summary="Detect watermark",
+    description="Checks if a PNG image contains a watermark and returns the owner identity if found.",
+)
 async def detect(
     request: Request,
-    image: Annotated[UploadFile, File()],
+    image: Annotated[UploadFile, File(...)],
     principal: Annotated[str, Depends(require_principal)],
 ):
     settings = _settings(request)
     image_bytes = await image.read()
     if len(image_bytes) > _MAX_IMAGE_BYTES:
-        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+        raise HTTPException(
+            413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)"
+        )
     bearer_token = _bearer_from_request(request)
-    reservation = await reserve_tokens(settings, operation="DETECT", bearer_token=bearer_token)
+    reservation = await reserve_tokens(
+        settings, operation="DETECT", bearer_token=bearer_token
+    )
     try:
-        detection = detect_text(image_bytes, app_key=settings.watermark_app_key)
+        detection = detect_text(
+            image_bytes, app_key=settings.watermark_app_key
+        )
     except Exception:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise
-    await consume_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+    await consume_reservation(
+        settings,
+        reservation_id=reservation.reservation_id,
+        bearer_token=bearer_token,
+    )
     return {
         "watermarked": detection.watermarked,
         "ownerIdentity": detection.owner_identity,
@@ -231,68 +293,124 @@ async def detect(
     }
 
 
-@router.post("/extract")
+@router.post(
+    "/extract",
+    summary="Extract watermark text",
+    description="Extracts the hidden text from a watermarked PNG image. Requires owner or admin permissions.",
+)
 async def extract(
     request: Request,
-    image: Annotated[UploadFile, File()],
+    image: Annotated[UploadFile, File(...)],
     principal: Annotated[str, Depends(require_principal)],
 ):
     settings = _settings(request)
     image_bytes = await image.read()
     if len(image_bytes) > _MAX_IMAGE_BYTES:
-        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+        raise HTTPException(
+            413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)"
+        )
     bearer_token = _bearer_from_request(request)
-    reservation = await reserve_tokens(settings, operation="EXTRACT", bearer_token=bearer_token)
+    reservation = await reserve_tokens(
+        settings, operation="EXTRACT", bearer_token=bearer_token
+    )
     try:
-        detection = detect_text(image_bytes, app_key=settings.watermark_app_key)
+        detection = detect_text(
+            image_bytes, app_key=settings.watermark_app_key
+        )
         if not detection.watermarked:
-            await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+            await release_reservation(
+                settings,
+                reservation_id=reservation.reservation_id,
+                bearer_token=bearer_token,
+            )
             raise HTTPException(400, detail="No watermark found in this image")
-        if detection.owner_identity != principal and not _is_admin_token(bearer_token):
-            await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
-            raise HTTPException(403, detail="Requester is not allowed to read this watermark")
+        if detection.owner_identity != principal and not _is_admin_token(
+            bearer_token
+        ):
+            await release_reservation(
+                settings,
+                reservation_id=reservation.reservation_id,
+                bearer_token=bearer_token,
+            )
+            raise HTTPException(
+                403, detail="Requester is not allowed to read this watermark"
+            )
     except HTTPException:
         raise
     except Exception:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise
-    await consume_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+    await consume_reservation(
+        settings,
+        reservation_id=reservation.reservation_id,
+        bearer_token=bearer_token,
+    )
     return {"ownerIdentity": detection.owner_identity, "text": detection.text}
 
 
-@router.post("/visualize")
+@router.post(
+    "/visualize",
+    summary="Visualize watermark",
+    description="Generates a heatmap showing the watermark distribution in the PNG image.",
+)
 async def visualize_endpoint(
     request: Request,
-    image: Annotated[UploadFile, File()],
+    image: Annotated[UploadFile, File(...)],
     principal: Annotated[str, Depends(require_principal)],
 ):
     settings = _settings(request)
     image_bytes = await image.read()
     if len(image_bytes) > _MAX_IMAGE_BYTES:
-        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+        raise HTTPException(
+            413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)"
+        )
     bearer_token = _bearer_from_request(request)
-    reservation = await reserve_tokens(settings, operation="VISUALIZE", bearer_token=bearer_token)
+    reservation = await reserve_tokens(
+        settings, operation="VISUALIZE", bearer_token=bearer_token
+    )
     try:
         heatmap = visualize(image_bytes, app_key=settings.watermark_app_key)
     except ValueError as exc:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise HTTPException(400, detail=str(exc))
     except Exception:
-        await release_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+        await release_reservation(
+            settings,
+            reservation_id=reservation.reservation_id,
+            bearer_token=bearer_token,
+        )
         raise
-    await consume_reservation(settings, reservation_id=reservation.reservation_id, bearer_token=bearer_token)
+    await consume_reservation(
+        settings,
+        reservation_id=reservation.reservation_id,
+        bearer_token=bearer_token,
+    )
     return Response(content=heatmap, media_type="image/png")
 
 
-@router.post("/capacity")
+@router.post(
+    "/capacity",
+    summary="Check watermark capacity",
+    description="Calculates the maximum text size that can be embedded into the provided image.",
+)
 async def capacity(
     request: Request,
-    image: Annotated[UploadFile, File()],
+    image: Annotated[UploadFile, File(...)],
     principal: Annotated[str, Depends(require_principal)],
 ):
     image_bytes = await image.read()
     if len(image_bytes) > _MAX_IMAGE_BYTES:
-        raise HTTPException(413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)")
+        raise HTTPException(
+            413, detail=f"Image too large (max {_MAX_IMAGE_BYTES} bytes)"
+        )
     report = capacity_report(image_bytes, owner=principal)
     return {
         "maxTextBytes": report.max_text_bytes,


### PR DESCRIPTION
- Added springdoc-openapi to Java services (ai, auth, subscription)
- Added technical descriptions to FastAPI routes in watermark-service
- Updated README.md with OpenAPI documentation links
- Exposed ai-service port in docker-compose for Swagger access
- Configured security to permit access to Swagger UI endpoints

Closes #27