### PR TITLE
Feature/42 fix paid sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,21 @@ System uzywa planow subskrypcji i tokenow. Kazda platna operacja najpierw rezerw
 | `EMBED_1024` | 8 |
 | `AI_CLASSIFICATION` | 2 |
 
-| Plan | Tokeny demo | Dozwolone operacje |
+| Plan | Tokeny / miesiac | Dozwolone operacje |
 |---|---:|---|
 | `FREE` | 50 | `CAPACITY_CHECK`, `DETECT`, `EMBED_768` |
 | `STANDARD` | 500 | `CAPACITY_CHECK`, `DETECT`, `EXTRACT`, `VISUALIZE`, `EMBED_768`, `EMBED_1024` |
 | `PRO` | 2500 | wszystkie operacje, wlacznie z `AI_CLASSIFICATION` |
+
+Cykl zycia subskrypcji:
+
+- dozwolone sa wylacznie przejscia `FREE -> STANDARD`, `FREE -> PRO` i `STANDARD -> PRO`,
+- downgrade oraz ponowny zakup aktywnego planu sa blokowane po stronie backendu,
+- platny plan jest wazny przez jeden miesiac od daty zakupu lub upgrade'u,
+- upgrade rozpoczyna nowy miesieczny okres i dodaje pelna pule tokenow nowego planu do aktualnego salda,
+- po wygasnieciu plan wraca do `FREE`, a saldo jest resetowane do 50 tokenow,
+- rezerwacje rozpoczete przed wygasnieciem moga zostac rozliczone, ale wygasly plan nie pozwala rozpoczynac nowych operacji,
+- finalizacja platnosci jest idempotentna i wymaga wlasciciela danej sesji platniczej.
 
 Zasady watermarkingu:
 
@@ -70,6 +80,7 @@ Zasady watermarkingu:
 - klasyfikacja AI jest opcjonalna i wykonywana tylko wtedy, gdy plan oraz saldo tokenow na to pozwalaja,
 - zwykly uzytkownik moze odczytywac tylko swoje watermarki,
 - administrator moze wykonywac detect/extract/visualize dla kazdego obrazu.
+- GUI przyjmuje obrazy o maksymalnym rozmiarze 20 MB i pokazuje date waznosci aktywnego planu.
 
 ## Mechanizmy Javy 21
 
@@ -213,6 +224,10 @@ Subscription:
 GET  /api/subscriptions/plans
 GET  /api/subscriptions/me
 GET  /api/subscriptions/me/tokens
+POST /api/payments/mock/sessions
+POST /api/payments/mock/sessions/{sessionId}/succeed
+POST /api/payments/mock/sessions/{sessionId}/fail
+POST /api/payments/mock/sessions/{sessionId}/cancel
 POST /api/tokens/reservations
 POST /api/tokens/reservations/{reservationId}/consume
 POST /api/tokens/reservations/{reservationId}/release

--- a/gui/src/routes/+page.svelte
+++ b/gui/src/routes/+page.svelte
@@ -22,6 +22,10 @@
         { id: "pricing", label: "Pricing" },
     ];
 
+    const planOrder = ["FREE", "STANDARD", "PRO"];
+    const maxImageSizeBytes = 20_000_000;
+    const maxImageSizeLabel = "20 MB";
+
     const operationCosts = {
         CAPACITY_CHECK: 0,
         DETECT: 1,
@@ -174,6 +178,21 @@
         }
     }
 
+    function canUpgradeTo(targetPlan) {
+        return (
+            planOrder.indexOf(targetPlan) >
+            planOrder.indexOf(subscription?.planCode)
+        );
+    }
+
+    function formatPlanExpiry(activeUntil) {
+        if (!activeUntil) return "No expiration";
+        return new Intl.DateTimeFormat("pl-PL", {
+            dateStyle: "medium",
+            timeStyle: "short",
+        }).format(new Date(activeUntil));
+    }
+
     async function completePayment(outcome) {
         if (!paymentSession) return;
         paymentError = "";
@@ -291,6 +310,8 @@
         if (!files || files.length === 0) return "Wybierz obraz z dysku.";
         if (files[0].size < 100)
             return "Wybrany plik jest zbyt mały lub uszkodzony.";
+        if (files[0].size > maxImageSizeBytes)
+            return `Wybrany obraz jest za duży. Maksymalny rozmiar pliku to ${maxImageSizeLabel}.`;
         return "";
     }
 
@@ -306,6 +327,8 @@
     }
 
     async function readError(response) {
+        if (response.status === 413)
+            return `Wybrany obraz jest za duży. Maksymalny rozmiar pliku to ${maxImageSizeLabel}.`;
         try {
             const data = await response.json();
             if (typeof data.detail === "string") return data.detail;
@@ -330,10 +353,15 @@
     async function probeCapacity() {
         if (!embedFiles || embedFiles.length === 0) return;
         capacityAbort?.abort();
+        const validation = validateImage(embedFiles);
+        capacity = null;
+        capacityError = validation || null;
+        if (validation) {
+            capacityChecking = false;
+            return;
+        }
         const controller = new AbortController();
         capacityAbort = controller;
-        capacity = null;
-        capacityError = null;
         capacityChecking = true;
         try {
             const formData = new FormData();
@@ -594,6 +622,14 @@
             <div class="metric">
                 <span>Role</span>
                 <strong>{currentRole}</strong>
+            </div>
+            <div class="metric">
+                <span>Plan valid until</span>
+                <strong
+                    class:metric-date={Boolean(subscription?.activeUntil)}
+                    title={subscription?.activeUntil ?? undefined}
+                    >{formatPlanExpiry(subscription?.activeUntil)}</strong
+                >
             </div>
             <button class="btn btn-outline compact" onclick={loadAccount}
                 >Refresh</button
@@ -913,7 +949,7 @@
                             <button class="btn btn-outline" disabled
                                 >Current plan</button
                             >
-                        {:else}
+                        {:else if canUpgradeTo(plan.code)}
                             <button
                                 class="btn btn-primary"
                                 onclick={() => initiatePayment(plan.code)}
@@ -921,6 +957,10 @@
                             >
                                 Upgrade to {plan.code}
                             </button>
+                        {:else}
+                            <button class="btn btn-outline" disabled
+                                >Downgrade unavailable</button
+                            >
                         {/if}
                     </div>
                 {/each}
@@ -1053,7 +1093,7 @@
 
     .account-panel {
         display: grid;
-        grid-template-columns: repeat(4, minmax(120px, 1fr)) auto;
+        grid-template-columns: repeat(5, minmax(110px, 1fr)) auto;
         gap: 10px;
         align-items: stretch;
         margin-bottom: 18px;
@@ -1087,9 +1127,13 @@
         font-size: 1.2rem;
     }
 
+    .metric strong.metric-date {
+        font-size: 0.95rem;
+    }
+
     .tabs {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(5, minmax(0, 1fr));
         gap: 8px;
         margin-bottom: 18px;
     }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/application/PaymentApplicationService.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/application/PaymentApplicationService.java
@@ -1,9 +1,12 @@
 package pl.zzpj.subscription_service.application;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import pl.zzpj.subscription_service.domain.payment.PaymentCompletion;
 import pl.zzpj.subscription_service.domain.payment.PaymentOutcome;
 import pl.zzpj.subscription_service.domain.payment.PaymentProvider;
 import pl.zzpj.subscription_service.domain.payment.PaymentSession;
@@ -21,26 +24,37 @@ public class PaymentApplicationService {
   private final SubscriptionStore subscriptionStore;
   private final SubscriptionCatalog subscriptionCatalog;
   private final SubscriptionQueryService subscriptionQueryService;
+  private final Clock clock;
 
   public PaymentApplicationService(
       PaymentProvider paymentProvider,
       SubscriptionStore subscriptionStore,
       SubscriptionCatalog subscriptionCatalog,
-      SubscriptionQueryService subscriptionQueryService) {
+      SubscriptionQueryService subscriptionQueryService,
+      Clock clock) {
     this.paymentProvider = paymentProvider;
     this.subscriptionStore = subscriptionStore;
     this.subscriptionCatalog = subscriptionCatalog;
     this.subscriptionQueryService = subscriptionQueryService;
+    this.clock = clock;
   }
 
   @Transactional
   public PaymentSession initiatePayment(String userId, PlanCode targetPlan) {
+    UserSubscriptionState currentState = subscriptionQueryService.stateFor(userId);
+    ensureSubscriptionReadyForUpgrade(currentState);
+    ensureUpgradeAllowed(currentState.subscription().planCode(), targetPlan);
     return paymentProvider.createSession(userId, targetPlan);
   }
 
   @Transactional
-  public PaymentSession completePayment(UUID sessionId, PaymentOutcome outcome) {
-    PaymentSession session = paymentProvider.completeSession(sessionId, outcome);
+  public PaymentSession completePayment(String userId, UUID sessionId, PaymentOutcome outcome) {
+    PaymentCompletion completion = paymentProvider.completeSession(sessionId, userId, outcome);
+    PaymentSession session = completion.session();
+
+    if (!completion.completedNow()) {
+      return session;
+    }
 
     switch (outcome) {
       case PaymentOutcome.Succeeded succeeded -> applyPaymentSuccess(session);
@@ -62,15 +76,45 @@ public class PaymentApplicationService {
             .orElseThrow(
                 () -> new IllegalStateException("Plan not found: " + session.targetPlan()));
 
-    UserSubscriptionState currentState = subscriptionQueryService.stateFor(session.userId());
+    subscriptionQueryService.stateFor(session.userId());
+    UserSubscriptionState currentState =
+        subscriptionStore
+            .findForUpdate(session.userId())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Subscription not found for user " + session.userId()));
+    ensureSubscriptionReadyForUpgrade(currentState);
+    ensureUpgradeAllowed(currentState.subscription().planCode(), session.targetPlan());
+
+    Instant now = clock.instant();
 
     ActiveSubscription updatedSubscription =
-        new ActiveSubscription(session.userId(), session.targetPlan(), Instant.now(), null);
+        new ActiveSubscription(
+            session.userId(),
+            session.targetPlan(),
+            now,
+            now.atZone(ZoneOffset.UTC).plusMonths(1).toInstant());
 
     TokenBalance updatedTokenBalance =
         new TokenBalance(
-            session.userId(), plan.monthlyTokens(), currentState.tokenBalance().reservedTokens());
+            session.userId(),
+            Math.addExact(currentState.tokenBalance().availableTokens(), plan.monthlyTokens()),
+            currentState.tokenBalance().reservedTokens());
 
     subscriptionStore.save(new UserSubscriptionState(updatedSubscription, updatedTokenBalance));
+  }
+
+  private void ensureUpgradeAllowed(PlanCode currentPlan, PlanCode targetPlan) {
+    if (!currentPlan.canUpgradeTo(targetPlan)) {
+      throw new IllegalArgumentException(
+          "Plan change from " + currentPlan + " to " + targetPlan + " is not an upgrade");
+    }
+  }
+
+  private void ensureSubscriptionReadyForUpgrade(UserSubscriptionState currentState) {
+    if (currentState.subscription().isExpiredAt(clock.instant())) {
+      throw new IllegalStateException("Expired subscription still has pending token reservations");
+    }
   }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/application/SubscriptionQueryService.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/application/SubscriptionQueryService.java
@@ -47,6 +47,22 @@ public class SubscriptionQueryService {
             new ActiveSubscription(userId, defaultPlan.code(), clock.instant(), null),
             new TokenBalance(userId, defaultPlan.monthlyTokens(), 0));
 
-    return subscriptionStore.getOrCreate(userId, initialState);
+    UserSubscriptionState state = subscriptionStore.getOrCreate(userId, initialState);
+    return expirePaidPlanIfEligible(state, defaultPlan);
+  }
+
+  private UserSubscriptionState expirePaidPlanIfEligible(
+      UserSubscriptionState state, SubscriptionPlan defaultPlan) {
+    if (!state.subscription().isExpiredAt(clock.instant())
+        || state.tokenBalance().reservedTokens() > 0) {
+      return state;
+    }
+
+    UserSubscriptionState freeState =
+        new UserSubscriptionState(
+            new ActiveSubscription(
+                state.subscription().userId(), defaultPlan.code(), clock.instant(), null),
+            new TokenBalance(state.tokenBalance().userId(), defaultPlan.monthlyTokens(), 0));
+    return subscriptionStore.save(freeState);
   }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/application/TokenReservationCommandService.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/application/TokenReservationCommandService.java
@@ -12,17 +12,15 @@ import pl.zzpj.subscription_service.domain.token.TokenReservationPolicy;
 import pl.zzpj.subscription_service.domain.token.decision.Accepted;
 import pl.zzpj.subscription_service.domain.token.decision.TokenDecision;
 import pl.zzpj.subscription_service.domain.token.reservation.TokenReservationStatus;
-import pl.zzpj.subscription_service.persistence.entity.ActiveSubscriptionEntity;
 import pl.zzpj.subscription_service.persistence.entity.TokenBalanceEntity;
 import pl.zzpj.subscription_service.persistence.entity.TokenReservationEntity;
-import pl.zzpj.subscription_service.persistence.repository.ActiveSubscriptionRepository;
 import pl.zzpj.subscription_service.persistence.repository.TokenBalanceRepository;
 import pl.zzpj.subscription_service.persistence.repository.TokenReservationRepository;
 
 @Service
 public class TokenReservationCommandService {
 
-  private final ActiveSubscriptionRepository subscriptionRepository;
+  private final SubscriptionQueryService subscriptionQueryService;
   private final TokenBalanceRepository tokenBalanceRepository;
   private final TokenReservationRepository tokenReservationRepository;
   private final TokenReservationPolicy reservationPolicy;
@@ -32,12 +30,12 @@ public class TokenReservationCommandService {
       "Token balance not found for authenticated user ";
 
   public TokenReservationCommandService(
-      ActiveSubscriptionRepository subscriptionRepository,
+      SubscriptionQueryService subscriptionQueryService,
       TokenBalanceRepository tokenBalanceRepository,
       TokenReservationRepository tokenReservationRepository,
       TokenReservationPolicy reservationPolicy,
       Clock clock) {
-    this.subscriptionRepository = subscriptionRepository;
+    this.subscriptionQueryService = subscriptionQueryService;
     this.tokenBalanceRepository = tokenBalanceRepository;
     this.tokenReservationRepository = tokenReservationRepository;
     this.reservationPolicy = reservationPolicy;
@@ -46,19 +44,9 @@ public class TokenReservationCommandService {
 
   @Transactional
   public TokenDecision reserve(String userId, CreateTokenReservationCommand command) {
-    ActiveSubscription subscription =
-        subscriptionRepository
-            .findById(userId)
-            .map(ActiveSubscriptionEntity::toDomain)
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Subscription not found for authenticated user " + userId));
-    TokenBalance tokenBalance =
-        tokenBalanceRepository
-            .findById(userId)
-            .map(TokenBalanceEntity::toDomain)
-            .orElseThrow(() -> new IllegalStateException(TOKEN_BALANCE_NOT_FOUND_ERROR + userId));
+    UserSubscriptionState state = subscriptionQueryService.stateFor(userId);
+    ActiveSubscription subscription = state.subscription();
+    TokenBalance tokenBalance = state.tokenBalance();
 
     Instant now = clock.instant();
     TokenDecision decision =
@@ -86,7 +74,9 @@ public class TokenReservationCommandService {
     TokenBalance updatedBalance = tokenBalance.consumeReserved(reservation.getTokens());
     tokenBalanceRepository.save(TokenBalanceEntity.from(updatedBalance));
     reservation.markConsumed(clock.instant());
-    return tokenReservationRepository.save(reservation);
+    TokenReservationEntity savedReservation = tokenReservationRepository.save(reservation);
+    subscriptionQueryService.stateFor(userId);
+    return savedReservation;
   }
 
   @Transactional
@@ -103,7 +93,9 @@ public class TokenReservationCommandService {
     TokenBalance updatedBalance = tokenBalance.releaseReserved(reservation.getTokens());
     tokenBalanceRepository.save(TokenBalanceEntity.from(updatedBalance));
     reservation.markReleased(clock.instant());
-    return tokenReservationRepository.save(reservation);
+    TokenReservationEntity savedReservation = tokenReservationRepository.save(reservation);
+    subscriptionQueryService.stateFor(userId);
+    return savedReservation;
   }
 
   private TokenReservationEntity findOwnedReservation(String userId, UUID reservationId) {

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/MockPaymentController.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/MockPaymentController.java
@@ -32,24 +32,28 @@ public class MockPaymentController {
   }
 
   @PostMapping("/{sessionId}/succeed")
-  public PaymentSessionResponse succeed(@PathVariable UUID sessionId) {
+  public PaymentSessionResponse succeed(@PathVariable UUID sessionId, Principal principal) {
+    String userId = userIdentityResolver.resolve(principal);
     PaymentSession session =
         paymentService.completePayment(
-            sessionId, new PaymentOutcome.Succeeded(UUID.randomUUID().toString()));
+            userId, sessionId, new PaymentOutcome.Succeeded(UUID.randomUUID().toString()));
     return PaymentSessionResponse.from(session);
   }
 
   @PostMapping("/{sessionId}/fail")
-  public PaymentSessionResponse fail(@PathVariable UUID sessionId) {
+  public PaymentSessionResponse fail(@PathVariable UUID sessionId, Principal principal) {
+    String userId = userIdentityResolver.resolve(principal);
     PaymentSession session =
-        paymentService.completePayment(sessionId, new PaymentOutcome.Failed("Mocked failure"));
+        paymentService.completePayment(
+            userId, sessionId, new PaymentOutcome.Failed("Mocked failure"));
     return PaymentSessionResponse.from(session);
   }
 
   @PostMapping("/{sessionId}/cancel")
-  public PaymentSessionResponse cancel(@PathVariable UUID sessionId) {
+  public PaymentSessionResponse cancel(@PathVariable UUID sessionId, Principal principal) {
+    String userId = userIdentityResolver.resolve(principal);
     PaymentSession session =
-        paymentService.completePayment(sessionId, new PaymentOutcome.Cancelled());
+        paymentService.completePayment(userId, sessionId, new PaymentOutcome.Cancelled());
     return PaymentSessionResponse.from(session);
   }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/TokenReservationController.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/TokenReservationController.java
@@ -20,6 +20,7 @@ import pl.zzpj.subscription_service.domain.token.decision.Accepted;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedInsufficientTokens;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedOperationNotAllowed;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedPlanNotFound;
+import pl.zzpj.subscription_service.domain.token.decision.RejectedSubscriptionExpired;
 import pl.zzpj.subscription_service.domain.token.decision.TokenDecision;
 import pl.zzpj.subscription_service.persistence.entity.TokenReservationEntity;
 
@@ -84,6 +85,9 @@ public class TokenReservationController {
       case RejectedPlanNotFound rejected ->
           ResponseEntity.status(HttpStatus.CONFLICT)
               .body(TokenReservationErrorResponse.from("PLAN_NOT_FOUND", rejected));
+      case RejectedSubscriptionExpired rejected ->
+          ResponseEntity.status(HttpStatus.CONFLICT)
+              .body(TokenReservationErrorResponse.from("SUBSCRIPTION_EXPIRED", rejected));
     };
   }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/payment/PaymentCompletion.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/payment/PaymentCompletion.java
@@ -1,0 +1,3 @@
+package pl.zzpj.subscription_service.domain.payment;
+
+public record PaymentCompletion(PaymentSession session, boolean completedNow) {}

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/payment/PaymentProvider.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/payment/PaymentProvider.java
@@ -8,5 +8,5 @@ public interface PaymentProvider {
 
   PaymentSession getSession(UUID sessionId);
 
-  PaymentSession completeSession(UUID sessionId, PaymentOutcome outcome);
+  PaymentCompletion completeSession(UUID sessionId, String userId, PaymentOutcome outcome);
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/subscription/ActiveSubscription.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/subscription/ActiveSubscription.java
@@ -13,4 +13,9 @@ public record ActiveSubscription(
     Objects.requireNonNull(planCode, "planCode must not be null");
     Objects.requireNonNull(activeFrom, "activeFrom must not be null");
   }
+
+  public boolean isExpiredAt(Instant instant) {
+    Objects.requireNonNull(instant, "instant must not be null");
+    return activeUntil != null && !activeUntil.isAfter(instant);
+  }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/subscription/PlanCode.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/subscription/PlanCode.java
@@ -3,5 +3,9 @@ package pl.zzpj.subscription_service.domain.subscription;
 public enum PlanCode {
   FREE,
   STANDARD,
-  PRO
+  PRO;
+
+  public boolean canUpgradeTo(PlanCode targetPlan) {
+    return targetPlan != null && targetPlan.ordinal() > ordinal();
+  }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/token/TokenReservationPolicy.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/token/TokenReservationPolicy.java
@@ -12,6 +12,7 @@ import pl.zzpj.subscription_service.domain.token.decision.Accepted;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedInsufficientTokens;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedOperationNotAllowed;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedPlanNotFound;
+import pl.zzpj.subscription_service.domain.token.decision.RejectedSubscriptionExpired;
 import pl.zzpj.subscription_service.domain.token.decision.TokenDecision;
 
 public class TokenReservationPolicy {
@@ -46,6 +47,10 @@ public class TokenReservationPolicy {
     Objects.requireNonNull(balance, "balance must not be null");
     Objects.requireNonNull(operation, "operation must not be null");
     Objects.requireNonNull(now, "now must not be null");
+
+    if (subscription.isExpiredAt(now)) {
+      return new RejectedSubscriptionExpired(subscription.activeUntil());
+    }
 
     return subscriptionCatalog
         .findPlan(subscription.planCode())

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/token/decision/RejectedSubscriptionExpired.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/token/decision/RejectedSubscriptionExpired.java
@@ -1,0 +1,5 @@
+package pl.zzpj.subscription_service.domain.token.decision;
+
+import java.time.Instant;
+
+public record RejectedSubscriptionExpired(Instant expiredAt) implements TokenDecision {}

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/token/decision/TokenDecision.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/domain/token/decision/TokenDecision.java
@@ -6,7 +6,8 @@ public sealed interface TokenDecision
     permits Accepted,
         RejectedInsufficientTokens,
         RejectedOperationNotAllowed,
-        RejectedPlanNotFound {
+        RejectedPlanNotFound,
+        RejectedSubscriptionExpired {
 
   static String describe(TokenDecision decision) {
     return switch (decision) {
@@ -35,6 +36,7 @@ public sealed interface TokenDecision
       case RejectedOperationNotAllowed(var planCode, var operation) ->
           "Plan " + planCode + " does not allow operation " + operation;
       case RejectedPlanNotFound(var planCode) -> "Subscription plan " + planCode + " was not found";
+      case RejectedSubscriptionExpired(var expiredAt) -> "Subscription expired at " + expiredAt;
     };
   }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/infrastructure/payment/MockPaymentProvider.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/infrastructure/payment/MockPaymentProvider.java
@@ -2,6 +2,7 @@ package pl.zzpj.subscription_service.infrastructure.payment;
 
 import java.util.UUID;
 import org.springframework.stereotype.Component;
+import pl.zzpj.subscription_service.domain.payment.PaymentCompletion;
 import pl.zzpj.subscription_service.domain.payment.PaymentOutcome;
 import pl.zzpj.subscription_service.domain.payment.PaymentProvider;
 import pl.zzpj.subscription_service.domain.payment.PaymentSession;
@@ -34,10 +35,20 @@ public class MockPaymentProvider implements PaymentProvider {
   }
 
   @Override
-  public PaymentSession completeSession(UUID sessionId, PaymentOutcome outcome) {
-    PaymentSession session = getSession(sessionId);
+  public PaymentCompletion completeSession(UUID sessionId, String userId, PaymentOutcome outcome) {
+    PaymentSession session =
+        repository
+            .findByIdForUpdate(sessionId)
+            .map(PaymentSessionEntity::toDomain)
+            .orElseThrow(() -> new IllegalArgumentException("Session not found: " + sessionId));
+    if (!session.userId().equals(userId)) {
+      throw new IllegalArgumentException("Payment session belongs to another user");
+    }
     if (session.status() != PaymentSession.Status.PENDING) {
-      throw new IllegalStateException("Session already completed: " + sessionId);
+      if (session.status() == statusFor(outcome)) {
+        return new PaymentCompletion(session, false);
+      }
+      throw new IllegalStateException("Session already completed with status " + session.status());
     }
 
     PaymentSession updatedSession =
@@ -48,6 +59,14 @@ public class MockPaymentProvider implements PaymentProvider {
         };
 
     repository.save(PaymentSessionEntity.from(updatedSession));
-    return updatedSession;
+    return new PaymentCompletion(updatedSession, true);
+  }
+
+  private PaymentSession.Status statusFor(PaymentOutcome outcome) {
+    return switch (outcome) {
+      case PaymentOutcome.Succeeded succeeded -> PaymentSession.Status.SUCCEEDED;
+      case PaymentOutcome.Failed failed -> PaymentSession.Status.FAILED;
+      case PaymentOutcome.Cancelled cancelled -> PaymentSession.Status.CANCELLED;
+    };
   }
 }

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/SubscriptionStore.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/SubscriptionStore.java
@@ -48,6 +48,20 @@ public class SubscriptionStore {
                                 subscription.toDomain(), tokenBalance.toDomain())));
   }
 
+  @Transactional
+  public Optional<UserSubscriptionState> findForUpdate(String userId) {
+    return subscriptionRepository
+        .findByIdForUpdate(userId)
+        .flatMap(
+            subscription ->
+                tokenBalanceRepository
+                    .findById(userId)
+                    .map(
+                        tokenBalance ->
+                            new UserSubscriptionState(
+                                subscription.toDomain(), tokenBalance.toDomain())));
+  }
+
   private UserSubscriptionState create(UserSubscriptionState initialState) {
     subscriptionRepository.insertIfMissing(
         initialState.subscription().userId(),

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/ActiveSubscriptionRepository.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/ActiveSubscriptionRepository.java
@@ -1,7 +1,10 @@
 package pl.zzpj.subscription_service.persistence.repository;
 
+import jakarta.persistence.LockModeType;
 import java.time.Instant;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,14 +13,20 @@ import pl.zzpj.subscription_service.persistence.entity.ActiveSubscriptionEntity;
 public interface ActiveSubscriptionRepository
     extends JpaRepository<ActiveSubscriptionEntity, String> {
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      "select subscription from ActiveSubscriptionEntity subscription where subscription.userId ="
+          + " :userId")
+  Optional<ActiveSubscriptionEntity> findByIdForUpdate(@Param("userId") String userId);
+
   @Modifying
   @Query(
       value =
           """
-            INSERT INTO subscription_schema.active_subscriptions (user_id, plan_code, active_from, active_until)
-            VALUES (:userId, :planCode, :activeFrom, NULL)
-            ON CONFLICT (user_id) DO NOTHING
-            """,
+INSERT INTO subscription_schema.active_subscriptions (user_id, plan_code, active_from, active_until)
+VALUES (:userId, :planCode, :activeFrom, NULL)
+ON CONFLICT (user_id) DO NOTHING
+""",
       nativeQuery = true)
   void insertIfMissing(
       @Param("userId") String userId,

--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/PaymentSessionRepository.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/persistence/repository/PaymentSessionRepository.java
@@ -1,7 +1,17 @@
 package pl.zzpj.subscription_service.persistence.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import pl.zzpj.subscription_service.persistence.entity.PaymentSessionEntity;
 
-public interface PaymentSessionRepository extends JpaRepository<PaymentSessionEntity, UUID> {}
+public interface PaymentSessionRepository extends JpaRepository<PaymentSessionEntity, UUID> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select session from PaymentSessionEntity session where session.id = :id")
+  Optional<PaymentSessionEntity> findByIdForUpdate(@Param("id") UUID id);
+}

--- a/subscription-service/src/test/java/pl/zzpj/subscription_service/application/PaymentApplicationServiceTest.java
+++ b/subscription-service/src/test/java/pl/zzpj/subscription_service/application/PaymentApplicationServiceTest.java
@@ -1,0 +1,133 @@
+package pl.zzpj.subscription_service.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.zzpj.subscription_service.domain.payment.PaymentCompletion;
+import pl.zzpj.subscription_service.domain.payment.PaymentOutcome;
+import pl.zzpj.subscription_service.domain.payment.PaymentProvider;
+import pl.zzpj.subscription_service.domain.payment.PaymentSession;
+import pl.zzpj.subscription_service.domain.subscription.ActiveSubscription;
+import pl.zzpj.subscription_service.domain.subscription.PlanCode;
+import pl.zzpj.subscription_service.domain.subscription.SubscriptionCatalog;
+import pl.zzpj.subscription_service.domain.subscription.SubscriptionPlan;
+import pl.zzpj.subscription_service.domain.token.TokenBalance;
+import pl.zzpj.subscription_service.persistence.SubscriptionStore;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentApplicationServiceTest {
+
+  @Mock private PaymentProvider paymentProvider;
+
+  @Mock private SubscriptionStore subscriptionStore;
+
+  @Mock private SubscriptionCatalog subscriptionCatalog;
+
+  @Mock private SubscriptionQueryService subscriptionQueryService;
+
+  private final Instant now = Instant.parse("2026-06-18T12:00:00Z");
+  private final Clock clock = Clock.fixed(now, ZoneOffset.UTC);
+
+  private PaymentApplicationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PaymentApplicationService(
+            paymentProvider,
+            subscriptionStore,
+            subscriptionCatalog,
+            subscriptionQueryService,
+            clock);
+  }
+
+  @Test
+  void shouldRejectDowngradeWhenCreatingPaymentSession() {
+    String userId = "user123";
+    when(subscriptionQueryService.stateFor(userId)).thenReturn(state(userId, PlanCode.PRO, 100, 0));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> service.initiatePayment(userId, PlanCode.STANDARD));
+    verify(paymentProvider, never()).createSession(any(), any());
+  }
+
+  @Test
+  void shouldAddPlanTokensAndStartNewMonthlyPeriodOnUpgrade() {
+    String userId = "user123";
+    UUID sessionId = UUID.randomUUID();
+    PaymentSession session =
+        new PaymentSession(
+            sessionId,
+            userId,
+            PlanCode.PRO,
+            PaymentSession.Status.SUCCEEDED,
+            now.minusSeconds(10),
+            now);
+    UserSubscriptionState currentState = state(userId, PlanCode.STANDARD, 420, 3);
+
+    when(paymentProvider.completeSession(
+            sessionId, userId, new PaymentOutcome.Succeeded("transaction")))
+        .thenReturn(new PaymentCompletion(session, true));
+    when(subscriptionCatalog.findPlan(PlanCode.PRO))
+        .thenReturn(Optional.of(new SubscriptionPlan(PlanCode.PRO, 2500, Set.of())));
+    when(subscriptionStore.findForUpdate(userId)).thenReturn(Optional.of(currentState));
+    when(subscriptionStore.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.completePayment(userId, sessionId, new PaymentOutcome.Succeeded("transaction"));
+
+    ArgumentCaptor<UserSubscriptionState> stateCaptor =
+        ArgumentCaptor.forClass(UserSubscriptionState.class);
+    verify(subscriptionStore).save(stateCaptor.capture());
+    UserSubscriptionState savedState = stateCaptor.getValue();
+    assertEquals(PlanCode.PRO, savedState.subscription().planCode());
+    assertEquals(now, savedState.subscription().activeFrom());
+    assertEquals(Instant.parse("2026-07-18T12:00:00Z"), savedState.subscription().activeUntil());
+    assertEquals(2920, savedState.tokenBalance().availableTokens());
+    assertEquals(3, savedState.tokenBalance().reservedTokens());
+  }
+
+  @Test
+  void shouldNotApplyTokensAgainForIdempotentCompletion() {
+    String userId = "user123";
+    UUID sessionId = UUID.randomUUID();
+    PaymentSession session =
+        new PaymentSession(
+            sessionId,
+            userId,
+            PlanCode.PRO,
+            PaymentSession.Status.SUCCEEDED,
+            now.minusSeconds(10),
+            now);
+    PaymentOutcome outcome = new PaymentOutcome.Succeeded("transaction");
+    when(paymentProvider.completeSession(sessionId, userId, outcome))
+        .thenReturn(new PaymentCompletion(session, false));
+
+    service.completePayment(userId, sessionId, outcome);
+
+    verify(subscriptionStore, never()).save(any());
+    verify(subscriptionCatalog, never()).findPlan(any());
+  }
+
+  private UserSubscriptionState state(
+      String userId, PlanCode planCode, int availableTokens, int reservedTokens) {
+    return new UserSubscriptionState(
+        new ActiveSubscription(userId, planCode, now.minusSeconds(60), null),
+        new TokenBalance(userId, availableTokens, reservedTokens));
+  }
+}

--- a/subscription-service/src/test/java/pl/zzpj/subscription_service/application/SubscriptionQueryServiceTest.java
+++ b/subscription-service/src/test/java/pl/zzpj/subscription_service/application/SubscriptionQueryServiceTest.java
@@ -3,6 +3,7 @@ package pl.zzpj.subscription_service.application;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -70,5 +71,51 @@ class SubscriptionQueryServiceTest {
     UserSubscriptionState actualState = subscriptionQueryService.stateFor(userId);
 
     assertEquals(expectedState, actualState);
+  }
+
+  @Test
+  void shouldResetExpiredPaidPlanToFreeWhenReservationsAreSettled() {
+    String userId = "user123";
+    SubscriptionPlan free = new SubscriptionPlan(PlanCode.FREE, 50, Set.of());
+    when(subscriptionCatalog.findPlan(PlanCode.FREE)).thenReturn(Optional.of(free));
+
+    UserSubscriptionState expiredState =
+        new UserSubscriptionState(
+            new ActiveSubscription(
+                userId,
+                PlanCode.PRO,
+                fixedInstant.minusSeconds(2_000_000),
+                fixedInstant.minusSeconds(1)),
+            new TokenBalance(userId, 1234, 0));
+    when(subscriptionStore.getOrCreate(eq(userId), any())).thenReturn(expiredState);
+    when(subscriptionStore.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    UserSubscriptionState actualState = subscriptionQueryService.stateFor(userId);
+
+    assertEquals(PlanCode.FREE, actualState.subscription().planCode());
+    assertEquals(50, actualState.tokenBalance().availableTokens());
+    assertEquals(0, actualState.tokenBalance().reservedTokens());
+    verify(subscriptionStore).save(actualState);
+  }
+
+  @Test
+  void shouldWaitForReservedTokensBeforeResettingExpiredPlan() {
+    String userId = "user123";
+    SubscriptionPlan free = new SubscriptionPlan(PlanCode.FREE, 50, Set.of());
+    when(subscriptionCatalog.findPlan(PlanCode.FREE)).thenReturn(Optional.of(free));
+
+    UserSubscriptionState expiredState =
+        new UserSubscriptionState(
+            new ActiveSubscription(
+                userId,
+                PlanCode.PRO,
+                fixedInstant.minusSeconds(2_000_000),
+                fixedInstant.minusSeconds(1)),
+            new TokenBalance(userId, 1234, 3));
+    when(subscriptionStore.getOrCreate(eq(userId), any())).thenReturn(expiredState);
+
+    UserSubscriptionState actualState = subscriptionQueryService.stateFor(userId);
+
+    assertEquals(expiredState, actualState);
   }
 }

--- a/subscription-service/src/test/java/pl/zzpj/subscription_service/application/TokenReservationCommandServiceTest.java
+++ b/subscription-service/src/test/java/pl/zzpj/subscription_service/application/TokenReservationCommandServiceTest.java
@@ -25,17 +25,15 @@ import pl.zzpj.subscription_service.domain.token.decision.Accepted;
 import pl.zzpj.subscription_service.domain.token.decision.RejectedInsufficientTokens;
 import pl.zzpj.subscription_service.domain.token.decision.TokenDecision;
 import pl.zzpj.subscription_service.domain.token.reservation.TokenReservationStatus;
-import pl.zzpj.subscription_service.persistence.entity.ActiveSubscriptionEntity;
 import pl.zzpj.subscription_service.persistence.entity.TokenBalanceEntity;
 import pl.zzpj.subscription_service.persistence.entity.TokenReservationEntity;
-import pl.zzpj.subscription_service.persistence.repository.ActiveSubscriptionRepository;
 import pl.zzpj.subscription_service.persistence.repository.TokenBalanceRepository;
 import pl.zzpj.subscription_service.persistence.repository.TokenReservationRepository;
 
 @ExtendWith(MockitoExtension.class)
 class TokenReservationCommandServiceTest {
 
-  @Mock private ActiveSubscriptionRepository subscriptionRepository;
+  @Mock private SubscriptionQueryService subscriptionQueryService;
 
   @Mock private TokenBalanceRepository tokenBalanceRepository;
 
@@ -52,7 +50,7 @@ class TokenReservationCommandServiceTest {
   void setUp() {
     service =
         new TokenReservationCommandService(
-            subscriptionRepository,
+            subscriptionQueryService,
             tokenBalanceRepository,
             tokenReservationRepository,
             reservationPolicy,
@@ -68,10 +66,8 @@ class TokenReservationCommandServiceTest {
     ActiveSubscription sub = new ActiveSubscription(userId, PlanCode.FREE, fixedInstant, null);
     TokenBalance balance = new TokenBalance(userId, 100, 0);
 
-    when(subscriptionRepository.findById(userId))
-        .thenReturn(Optional.of(ActiveSubscriptionEntity.from(sub)));
-    when(tokenBalanceRepository.findById(userId))
-        .thenReturn(Optional.of(TokenBalanceEntity.from(balance)));
+    when(subscriptionQueryService.stateFor(userId))
+        .thenReturn(new UserSubscriptionState(sub, balance));
 
     TokenReservation reservation =
         new TokenReservation(
@@ -96,10 +92,8 @@ class TokenReservationCommandServiceTest {
     ActiveSubscription sub = new ActiveSubscription(userId, PlanCode.FREE, fixedInstant, null);
     TokenBalance balance = new TokenBalance(userId, 0, 0);
 
-    when(subscriptionRepository.findById(userId))
-        .thenReturn(Optional.of(ActiveSubscriptionEntity.from(sub)));
-    when(tokenBalanceRepository.findById(userId))
-        .thenReturn(Optional.of(TokenBalanceEntity.from(balance)));
+    when(subscriptionQueryService.stateFor(userId))
+        .thenReturn(new UserSubscriptionState(sub, balance));
 
     TokenDecision decision = new RejectedInsufficientTokens(TokenOperation.DETECT, 1, 0);
     when(reservationPolicy.decide(any(), any(), eq(TokenOperation.DETECT), eq(fixedInstant)))

--- a/subscription-service/src/test/java/pl/zzpj/subscription_service/domain/token/TokenReservationPolicyTest.java
+++ b/subscription-service/src/test/java/pl/zzpj/subscription_service/domain/token/TokenReservationPolicyTest.java
@@ -1,0 +1,36 @@
+package pl.zzpj.subscription_service.domain.token;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import pl.zzpj.subscription_service.domain.pricing.PricingCatalog;
+import pl.zzpj.subscription_service.domain.subscription.ActiveSubscription;
+import pl.zzpj.subscription_service.domain.subscription.PlanCode;
+import pl.zzpj.subscription_service.domain.subscription.SubscriptionCatalog;
+import pl.zzpj.subscription_service.domain.subscription.SubscriptionPlan;
+import pl.zzpj.subscription_service.domain.token.decision.RejectedSubscriptionExpired;
+
+class TokenReservationPolicyTest {
+
+  @Test
+  void shouldRejectNewReservationForExpiredSubscription() {
+    Instant now = Instant.parse("2026-06-18T12:00:00Z");
+    SubscriptionPlan pro = new SubscriptionPlan(PlanCode.PRO, 2500, Set.of(TokenOperation.DETECT));
+    TokenReservationPolicy policy =
+        new TokenReservationPolicy(
+            new SubscriptionCatalog(Map.of(PlanCode.PRO, pro)),
+            new PricingCatalog(Map.of(TokenOperation.DETECT, 1)));
+    ActiveSubscription expiredSubscription =
+        new ActiveSubscription(
+            "user123", PlanCode.PRO, now.minusSeconds(2_000_000), now.minusSeconds(1));
+
+    var decision =
+        policy.decide(
+            expiredSubscription, new TokenBalance("user123", 100, 1), TokenOperation.DETECT, now);
+
+    assertInstanceOf(RejectedSubscriptionExpired.class, decision);
+  }
+}

--- a/subscription-service/src/test/java/pl/zzpj/subscription_service/infrastructure/payment/MockPaymentProviderTest.java
+++ b/subscription-service/src/test/java/pl/zzpj/subscription_service/infrastructure/payment/MockPaymentProviderTest.java
@@ -1,0 +1,64 @@
+package pl.zzpj.subscription_service.infrastructure.payment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.zzpj.subscription_service.domain.payment.PaymentOutcome;
+import pl.zzpj.subscription_service.domain.payment.PaymentSession;
+import pl.zzpj.subscription_service.domain.subscription.PlanCode;
+import pl.zzpj.subscription_service.persistence.entity.PaymentSessionEntity;
+import pl.zzpj.subscription_service.persistence.repository.PaymentSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MockPaymentProviderTest {
+
+  @Mock private PaymentSessionRepository repository;
+
+  @Test
+  void shouldReturnExistingResultForRepeatedSuccessfulCompletion() {
+    UUID sessionId = UUID.randomUUID();
+    PaymentSession succeededSession =
+        session(sessionId, "user123", PaymentSession.Status.SUCCEEDED);
+    when(repository.findByIdForUpdate(sessionId))
+        .thenReturn(Optional.of(PaymentSessionEntity.from(succeededSession)));
+    MockPaymentProvider provider = new MockPaymentProvider(repository);
+
+    var completion =
+        provider.completeSession(
+            sessionId, "user123", new PaymentOutcome.Succeeded("another-request-id"));
+
+    assertFalse(completion.completedNow());
+    verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void shouldRejectCompletionByAnotherUser() {
+    UUID sessionId = UUID.randomUUID();
+    PaymentSession pendingSession = session(sessionId, "owner", PaymentSession.Status.PENDING);
+    when(repository.findByIdForUpdate(sessionId))
+        .thenReturn(Optional.of(PaymentSessionEntity.from(pendingSession)));
+    MockPaymentProvider provider = new MockPaymentProvider(repository);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            provider.completeSession(
+                sessionId, "other-user", new PaymentOutcome.Succeeded("transaction")));
+    verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+  }
+
+  private PaymentSession session(UUID sessionId, String userId, PaymentSession.Status status) {
+    Instant now = Instant.parse("2026-06-18T12:00:00Z");
+    return new PaymentSession(sessionId, userId, PlanCode.PRO, status, now.minusSeconds(10), now);
+  }
+}


### PR DESCRIPTION
Implement paid subscription lifecycle with upgrade-only transitions, cumulative tokens, monthly expiration, and automatic fallback to FREE. Adds secure, idempotent mock payments, improved pricing UI, plan expiry display, upload-size validation, tests, and updated documentation.

Closes #42 