### PR TITLE
fix: restore REST mapping on token reservation controller (embed 404)

### DIFF
--- a/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/TokenReservationController.java
+++ b/subscription-service/src/main/java/pl/zzpj/subscription_service/controller/TokenReservationController.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import pl.zzpj.subscription_service.application.TokenReservationCommandService;
 import pl.zzpj.subscription_service.application.UserIdentityResolver;
 import pl.zzpj.subscription_service.application.command.CreateTokenReservationCommand;
@@ -24,6 +26,8 @@ import pl.zzpj.subscription_service.domain.token.decision.RejectedSubscriptionEx
 import pl.zzpj.subscription_service.domain.token.decision.TokenDecision;
 import pl.zzpj.subscription_service.persistence.entity.TokenReservationEntity;
 
+@RestController
+@RequestMapping("/api/tokens/reservations")
 @Tag(name = "Token Reservation", description = "API for managing token reservations for operations")
 public class TokenReservationController {
 


### PR DESCRIPTION
## Bugfix

Embedding a watermark failed with **`Could not reserve tokens for this operation`**.

### Root cause
`TokenReservationController` lost its `@RestController` and `@RequestMapping("/api/tokens/reservations")` annotations during the merge in #44 (only `@Tag` was left). Without `@RestController`, Spring never registers the controller, so **every** call to `/api/tokens/reservations` returned `404 Not Found`.

The `watermark-service` (Python) gets that 404, and because the 404 body has no `message` field it falls back to the generic message *"Could not reserve tokens for this operation"* — which is what the user sees on embed. It affected all token operations (embed, detect, extract, visualize), not just embed.

### Fix
Restore the two annotations (and their imports) that the other controllers in this service also use:

```java
@RestController
@RequestMapping("/api/tokens/reservations")
@Tag(...)
public class TokenReservationController {
```

### Verification
- Reproduced before the fix: `POST /api/tokens/reservations` returned `404` for `EMBED_768`, `EMBED_1024`, `DETECT`, `AI_CLASSIFICATION`.
- Rebuilt only the `subscription-service` container; the endpoint is now mapped and reaches the JWT filter / reservation logic (no longer 404).

### Note
A `@WebMvcTest` slice test for this controller would have caught the missing mapping — the existing tests only cover the application layer, so the regression slipped through. Happy to add one if we want.

cc @MateuszKosowski — please review 🙏